### PR TITLE
Remove redundant image tag for cos-dkms

### DIFF
--- a/deploy/base/node/node.yaml
+++ b/deploy/base/node/node.yaml
@@ -45,7 +45,7 @@ spec:
         cloud.google.com/gke-os-distribution: cos
       initContainers:
       - name: disable-loadpin
-        image: gcr.io/cos-cloud/cos-dkms:v0.3.0
+        image: gcr.io/cos-cloud/cos-dkms
         securityContext:
           privileged: true
         command: ["/bin/sh", "-c"]
@@ -69,7 +69,7 @@ spec:
         - name: dev
           mountPath: /dev
       - name: install-lustre-mods
-        image: gcr.io/cos-cloud/cos-dkms:v0.3.0
+        image: gcr.io/cos-cloud/cos-dkms
         securityContext:
          privileged: true
         command: ["/bin/sh", "-c"]


### PR DESCRIPTION
Removing redundant image tag as it is already present in https://github.com/GoogleCloudPlatform/lustre-csi-driver/blob/main/deploy/images/gke-release/image.yaml#L30