### PR TITLE
Switch back to 2.16 module verison for lustre drivers

### DIFF
--- a/deploy/base/node/node.yaml
+++ b/deploy/base/node/node.yaml
@@ -87,7 +87,8 @@ spec:
             #                                     parameter configures the port LNET will use. This is
             #                                     essential for proper communication between Lustre clients
             #                                     and servers. In this case, we're setting it to 6988.
-            /usr/bin/cos-dkms install lustre-client-drivers --gcs-bucket=cos-default --module-version=2.14.0_p184 --kernelmodulestree=/host_modules --module-arg=lnet.accept_port=6988 --lsb-release-path=/host_etc/lsb-release --insert-on-install --logtostderr
+            # TODO(rishitagolla): Set module version to 2.14 when gke picks up the required COS image.
+            /usr/bin/cos-dkms install lustre-client-drivers --gcs-bucket=cos-default --module-version=2.16.0 --kernelmodulestree=/host_modules --module-arg=lnet.accept_port=6988 --lsb-release-path=/host_etc/lsb-release --insert-on-install --logtostderr
         volumeMounts:
         - name: host-etc
           mountPath: /host_etc


### PR DESCRIPTION
Reverting previous PR changes since gke has not picked up cos-117-18613-164-93 yet.