### PR TITLE
[Do Not Merge] support lustre client cache tuning

### DIFF
--- a/cmd/kmod_installer/entrypoint.sh
+++ b/cmd/kmod_installer/entrypoint.sh
@@ -69,7 +69,7 @@ fi
 # TODO: Set module version to 2.14 when gke picks up cos-117-18613-164-93.
 /usr/bin/cos-dkms install lustre-client-drivers \
     --gcs-bucket=cos-default \
-    --module-version=2.16.0 \
+    --module-version=2.14.0_p184 \
     --kernelmodulestree=/host_modules \
     --module-arg=lnet.accept_port=${LNET_PORT} \
     --lsb-release-path=/host_etc/lsb-release \

--- a/examples/pre-prov/preprov-pvc-pv.yaml
+++ b/examples/pre-prov/preprov-pvc-pv.yaml
@@ -30,6 +30,10 @@ spec:
     volumeAttributes:
       ip: ${EXISTING_LUSTRE_IP_ADDRESS} # The IP address of the existing Lustre instance.
       filesystem: ${EXISTING_LUSTRE_FSNAME} # The filesystem name of the existing Lustre instance.
+      llite.*.max_cached_mb: 160G
+      llite.*.max_read_ahead_mb: 120G
+      llite.*.max_read_ahead_per_file_mb: 6G
+      llite.*.max_read_ahead_whole_mb: 6G
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -19,8 +19,10 @@ package driver
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/lustre-csi-driver/pkg/util"
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
@@ -129,6 +131,14 @@ func (s *nodeServer) NodeStageVolume(_ context.Context, req *csi.NodeStageVolume
 
 	if mounted {
 		klog.V(4).Infof("NodeStageVolume successfully mounted device %v to path %s on node %s, mount already exists.", volumeID, target, nodeName)
+		if err := setClientCaching(context); err != nil {
+			klog.Infof("setClientCaching failed for volume %q, cleaning up mount point %s on node %s", volumeID, target, nodeName)
+			if unmntErr := mount.CleanupMountPoint(target, s.mounter, false /* extensiveMountPointCheck */); unmntErr != nil {
+				klog.Errorf("Unmount %q failed on node %s: %v", target, nodeName, unmntErr.Error())
+			}
+
+			return nil, status.Error(codes.Internal, err.Error())
+		}
 
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
@@ -154,6 +164,15 @@ func (s *nodeServer) NodeStageVolume(_ context.Context, req *csi.NodeStageVolume
 		}
 
 		return nil, status.Errorf(codes.Internal, "Could not mount %q at %q on node %s: %v", source, target, nodeName, err)
+	}
+
+	if err := setClientCaching(context); err != nil {
+		klog.Infof("setClientCaching failed for volume %q, cleaning up mount point %s on node %s", volumeID, target, nodeName)
+		if unmntErr := mount.CleanupMountPoint(target, s.mounter, false /* extensiveMountPointCheck */); unmntErr != nil {
+			klog.Errorf("Unmount %q failed on node %s: %v", target, nodeName, unmntErr.Error())
+		}
+
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 
 	klog.V(4).Infof("NodeStageVolume successfully mounted volume %v to path %s on node %s", volumeID, target, nodeName)
@@ -530,6 +549,29 @@ func setVolumeOwnershipTopLevel(volumeID, dir, fsGroup string, readOnly bool) er
 		return err
 	}
 	klog.InfoS("NodePublishVolume successfully changed ownership and permissions of top-level directory", "volume", volumeID, "path", dir, "fsGroup", fsGroup)
+
+	return nil
+}
+
+func setClientCaching(volumeContext map[string]string) error {
+	var params []string
+	for key, value := range volumeContext {
+		if strings.HasPrefix(key, "llite") {
+			params = append(params, fmt.Sprintf("%s=%s", key, value))
+		}
+	}
+
+	if len(params) == 0 {
+		return nil
+	}
+
+	klog.Infof("Setting lustre client caching params: %q", params)
+	cmd := exec.Command("lctl", append([]string{"set_param"}, params...)...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
Support Lustre client cache tuning via volumeAttributes. See the example below for how Lustre kernel cache settings can be passed through.
```
apiVersion: v1
kind: PersistentVolume
metadata:
  name: preprov-pv
spec:
  storageClassName: ""
  capacity:
    storage: 16Ti
  accessModes:
    - ReadWriteMany
  persistentVolumeReclaimPolicy: Retain
  volumeMode: Filesystem
  csi:
    driver: lustre.csi.storage.gke.io
    volumeHandle: <project-id>/<instance-location>/<instance-name> # Modify this to use the project, zone, and mananged lustre instance name.
    volumeAttributes:
      ip: ${EXISTING_LUSTRE_IP_ADDRESS} # The IP address of the existing Lustre instance.
      filesystem: ${EXISTING_LUSTRE_FSNAME} # The filesystem name of the existing Lustre instance.
      llite.*.max_cached_mb: 160G
      llite.*.max_read_ahead_mb: 120G
      llite.*.max_read_ahead_per_file_mb: 6G
      llite.*.max_read_ahead_whole_mb: 6G
---
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: preprov-pvc
spec:
  accessModes:
    - ReadWriteMany
  storageClassName: ""
  volumeName: preprov-pv
  resources:
    requests:
      storage: 16Ti
```