### PR TITLE
fix to add storage prefix for mount flow

### DIFF
--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -37,6 +37,7 @@ import (
 const (
 	// Kubernetes prefixes.
 	csiPrefixKubernetesStorage = "csi.storage.k8s.io"
+	storagePrefixKubernetes    = "storage.kubernetes.io"
 
 	// Storage Class K8s parameters.
 	keyPVCName      = "csi.storage.k8s.io/pvc/name"

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -73,8 +73,9 @@ func normalizeKeys(input map[string]string, supported map[string]struct{}) (map[
 	for inputKey, inputVal := range input {
 		normalizedKey := normalize(inputKey)
 
-		// Don't validate k8s keys, keys such as csi.storage.k8s.io/pvc/name are added by the system.
-		isK8sKey := strings.HasPrefix(normalizedKey, csiPrefixKubernetesStorage)
+		// Don't validate k8s keys, keys such as csi.storage.k8s.io/pvc/name and storage.kubernetes.io are added by the system.
+		isK8sKey := strings.HasPrefix(normalizedKey, csiPrefixKubernetesStorage) ||
+			strings.HasPrefix(normalizedKey, storagePrefixKubernetes)
 
 		if _, ok := supported[normalizedKey]; !ok && !isK8sKey {
 			unsupported = append(unsupported, inputKey)


### PR DESCRIPTION
Added prefix `storage.kubernetes.io` in validation as it is required during mount time.