### PR TITLE
Update helm chart and driver images

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -29,7 +29,7 @@ curl -fsSL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
 1. Environment Setup
 
     ```sh
-    export VERSION=1.0.0    # Set lustre-csi-driver image tag
+    export VERSION=v0.2.1-gke.0    # Set lustre-csi-driver image tag
     export NAMESPACE="lustre-csi-driver"
     ```
 
@@ -54,6 +54,7 @@ curl -fsSL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
     - Create a Kubernetes secret from the service account key:
 
     ```sh
+    kubectl create namespace ${NAMESPACE}
     kubectl create secret generic lustre-csi-driver-sa \
         --from-file=${GSA_DIR}/lustre_csi_driver_sa.json \
         --namespace=${NAMESPACE}
@@ -67,7 +68,6 @@ curl -fsSL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
     ```sh
     helm upgrade -i lustre-csi-driver lustre-csi-driver \
       --namespace ${NAMESPACE} \
-      --create-namespace \
       --set image.lustre.tag="$VERSION"
     ```
 

--- a/helm/lustre-csi-driver/Chart.yaml
+++ b/helm/lustre-csi-driver/Chart.yaml
@@ -29,10 +29,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.0"
+appVersion: "0.2.1"

--- a/helm/lustre-csi-driver/templates/csi-controller.yaml
+++ b/helm/lustre-csi-driver/templates/csi-controller.yaml
@@ -98,6 +98,8 @@ spec:
             - "--endpoint=unix:/csi/csi.sock"
             - "--nodeid=$(KUBE_NODE_NAME)"
             - "--controller=true"
+            - "--lustre-endpoint=prod"
+            - "--enable-legacy-lustre-port=true"
           ports:
             - containerPort: 29633
               name: healthz

--- a/helm/lustre-csi-driver/templates/csi-node.yaml
+++ b/helm/lustre-csi-driver/templates/csi-node.yaml
@@ -43,48 +43,20 @@ spec:
         kubernetes.io/arch: amd64
         cloud.google.com/gke-os-distribution: cos
       initContainers:
-      - name: disable-loadpin
-        image: "{{ .Values.image.cos.repository }}:{{ .Values.image.cos.tag }}"
+      - name: lustre-kmod-installer
+        image: "{{ .Values.image.kmod.repository }}:{{ .Values.image.kmod.tag | default .Chart.AppVersion }}"
         securityContext:
-          privileged: true
-        command: ["/bin/sh", "-c"]
-        args:
-          - |
-            # Disable LoadPin if it's not already disabled
-            if cat /proc/cmdline | grep "loadpin"; then
-              echo "LoadPin has already been disabled. Move to kmod installation."
-            else
-              echo "Sleep 60s until the node is ready"
-              sleep 60
-              echo "LoadPin is not disabled. Disabling LoadPin now."
-              mkdir -p /mnt/disks
-              mount /dev/disk/by-label/EFI-SYSTEM /mnt/disks
-              sed -i -e 's|module.sig_enforce=0|module.sig_enforce=0 loadpin.enforce=0|g' /mnt/disks/efi/boot/grub.cfg
-              umount /mnt/disks
-              echo 1 > /proc/sys/kernel/sysrq
-              echo b > /proc/sysrq-trigger
-            fi
+         privileged: true
+        env:
+        - name: ENABLE_LEGACY_LUSTRE_PORT
+          value: "true"
+        - name: CHECK_LOADPIN
+          value: "true"
         volumeMounts:
         - name: dev
           mountPath: /dev
-      - name: install-lustre-mods
-        image: "{{ .Values.image.cos.repository }}:{{ .Values.image.cos.tag }}"
-        securityContext:
-         privileged: true
-        command: ["/bin/sh", "-c"]
-        args:
-          - |
-            # Install the latest Lustre client drivers.
-            #
-            # --gcs-bucket: Specifies the GCS bucket containing the driver packages ('cos-default').
-            # --latest: Installs the latest available driver version.
-            # --kernelmodulestree: Sets the path to the kernel modules directory on the host ('/host_modules').
-            # --lsb-release-path: Specifies the path to the lsb-release file on the host ('/host_etc/lsb-release').
-            # --insert-on-install: Inserts the module into the kernel after installation.
-            /usr/bin/cos-dkms install lustre-client-drivers --gcs-bucket=cos-default --latest --kernelmodulestree=/host_modules --module-arg=lnet.accept_port=6988 --lsb-release-path=/host_etc/lsb-release --insert-on-install --logtostderr
-        volumeMounts:
         - name: host-etc
-          mountPath: /host_etc
+          mountPath: /host_etc/lsb-release
         - name: host-modules
           mountPath: /host_modules
       containers:
@@ -160,7 +132,8 @@ spec:
             type: DirectoryOrCreate
         - name: host-etc
           hostPath:
-            path: /etc
+            path: /etc/lsb-release
+            type: File
         - name: host-modules
           hostPath:
             path: /lib/modules

--- a/helm/lustre-csi-driver/values.yaml
+++ b/helm/lustre-csi-driver/values.yaml
@@ -19,12 +19,12 @@
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
   lustre:
-    repository: "us-docker.pkg.dev/lustre-client-binaries/lustre-csi-driver/lustre-csi-driver"
-    tag: "1.0.0"
+    repository: "us.gcr.io/gke-release/lustre-csi-driver"
+    tag: v0.2.1-gke.0
     pullPolicy: Always
-  cos:
-    repository: "gcr.io/cos-cloud/cos-dkms"
-    tag: v0.3.0
+  kmod:
+    repository: "us.gcr.io/gke-release/lustre-kmod-installer"
+    tag: v0.2.1-gke.0
     pullPolicy: Always
 
 sidecars:


### PR DESCRIPTION
PR to update helm chart: https://github.com/GoogleCloudPlatform/lustre-csi-driver/issues/104

Changes include
1. Helm chart update to use --enable-legacy-lustre-port and lustre-kmod-installer image.
2. Driver image to use v0.2.1.
2. Updated README.