### PR TITLE
feat(volume-expansion): Add Volume Expansion Capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The Google Cloud Managed Lustre Container Storage Interface (CSI) Plugin.
 
 ## Project Overview
 
-The Lustre CSI driver allows k8s workloads (a group of k8s pods) to connect to Google Cloud Managed Lustre instances - transparently through the Kubernetes Persistent Volume Claims (PVCs) API. The Lustre CSI driver supports creating and deleting Google Cloud Managed Lustre instances, as well as mounting and unmounting them on GKE nodes in response to CSI calls, ensuring transparent and efficient integration with GKE environments.
+The Lustre CSI driver allows k8s workloads (a group of k8s pods) to connect to Google Cloud Managed Lustre instances - transparently through the Kubernetes Persistent Volume Claims (PVCs) API. The Lustre CSI driver supports creating, deleting, and expanding Google Cloud Managed Lustre instances, as well as mounting and unmounting them on GKE nodes in response to CSI calls, ensuring transparent and efficient integration with GKE environments.
 
 ## Project Status
 

--- a/deploy/base/controller/controller.yaml
+++ b/deploy/base/controller/controller.yaml
@@ -89,6 +89,37 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+        - name: csi-external-resizer
+          image: registry.k8s.io/sig-storage/csi-resizer
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--csi-address=/csi/csi.sock"
+            - "--timeout=250s"
+            - "--http-endpoint=:22022"
+            - "--leader-election"
+            - "--leader-election-namespace=$(LUSTRE_NAMESPACE)"
+            - "--handle-volume-inuse-error=false"
+          env:
+            - name: LUSTRE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - containerPort: 22022
+              name: http-endpoint
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 1
+            httpGet:
+              path: /healthz/leader-election
+              port: http-endpoint
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
+            periodSeconds: 20
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
         - name: lustre-csi-driver
           image: gke.gcr.io/lustre-csi-driver
           imagePullPolicy: IfNotPresent

--- a/deploy/base/controller/controller_setup.yaml
+++ b/deploy/base/controller/controller_setup.yaml
@@ -63,6 +63,37 @@ roleRef:
   name: lustre-csi-provisioner-role
   apiGroup: rbac.authorization.k8s.io
 ---
+# xref: https://github.com/kubernetes-csi/external-resizer/blob/master/deploy/kubernetes/rbac.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: lustre-csi-resizer-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: lustre-csi-resizer-binding
+subjects:
+  - kind: ServiceAccount
+    name: lustre-csi-controller-sa
+roleRef:
+  kind: ClusterRole
+  name: lustre-csi-resizer-role
+  apiGroup: rbac.authorization.k8s.io
+---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/deploy/images/stable/image.yaml
+++ b/deploy/images/stable/image.yaml
@@ -31,6 +31,14 @@ imageTag:
 apiVersion: builtin
 kind: ImageTagTransformer
 metadata:
+  name: imagetag-csi-resizer
+imageTag:
+  name: registry.k8s.io/sig-storage/csi-resizer
+  newTag: "v1.14.0"
+---
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
   name: imagetag-csi-node-registrar
 imageTag:
   name: registry.k8s.io/sig-storage/csi-node-driver-registrar

--- a/deploy/overlays/dev/storageclass.yaml
+++ b/deploy/overlays/dev/storageclass.yaml
@@ -19,6 +19,7 @@ metadata:
 provisioner: lustre.csi.storage.gke.io
 volumeBindingMode: Immediate
 reclaimPolicy: Delete
+allowVolumeExpansion: true
 allowedTopologies:
   - matchLabelExpressions:
     - key: topology.gke.io/zone

--- a/pkg/csi_driver/controller_unimpl.go
+++ b/pkg/csi_driver/controller_unimpl.go
@@ -31,10 +31,6 @@ func (s *controllerServer) ControllerUnpublishVolume(_ context.Context, _ *csi.C
 	return nil, status.Error(codes.Unimplemented, "ControllerUnpublishVolume unsupported")
 }
 
-func (s *controllerServer) ControllerExpandVolume(_ context.Context, _ *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "ControllerExpandVolume unsupported")
-}
-
 func (s *controllerServer) CreateSnapshot(_ context.Context, _ *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "CreateSnapshot unsupported")
 }

--- a/pkg/csi_driver/identity.go
+++ b/pkg/csi_driver/identity.go
@@ -50,6 +50,20 @@ func (s *identityServer) GetPluginCapabilities(_ context.Context, _ *csi.GetPlug
 				},
 			},
 			{
+				Type: &csi.PluginCapability_VolumeExpansion_{
+					VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
+						Type: csi.PluginCapability_VolumeExpansion_ONLINE,
+					},
+				},
+			},
+			{
+				Type: &csi.PluginCapability_VolumeExpansion_{
+					VolumeExpansion: &csi.PluginCapability_VolumeExpansion{
+						Type: csi.PluginCapability_VolumeExpansion_OFFLINE,
+					},
+				},
+			},
+			{
 				Type: &csi.PluginCapability_Service_{
 					Service: &csi.PluginCapability_Service{
 						Type: csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS,

--- a/pkg/csi_driver/identity_test.go
+++ b/pkg/csi_driver/identity_test.go
@@ -68,7 +68,7 @@ func TestGetPluginCapabilities(t *testing.T) {
 		t.Fatalf("GetPluginCapabilities resp is nil")
 	}
 
-	if len(resp.GetCapabilities()) != 2 {
+	if len(resp.GetCapabilities()) != 4 {
 		t.Fatalf("Got %d capabilities, want %d", len(resp.GetCapabilities()), 2)
 	}
 
@@ -84,13 +84,32 @@ func TestGetPluginCapabilities(t *testing.T) {
 	if serviceType := service.GetType(); serviceType != csi.PluginCapability_Service_CONTROLLER_SERVICE {
 		t.Fatalf("Got %v capability service, want %v", serviceType, csi.PluginCapability_Service_CONTROLLER_SERVICE)
 	}
-	service = resp.GetCapabilities()[1].GetService()
+
+	volumeExpansion := resp.GetCapabilities()[1].GetVolumeExpansion()
+	if volumeExpansion == nil {
+		t.Fatalf("Got nil volume expansion capability")
+	}
+
+	if expansionType := volumeExpansion.GetType(); expansionType != csi.PluginCapability_VolumeExpansion_ONLINE {
+		t.Fatalf("Got %v capability", expansionType)
+	}
+
+	volumeExpansion = resp.GetCapabilities()[2].GetVolumeExpansion()
+	if volumeExpansion == nil {
+		t.Fatalf("Got nil volume expansion capability")
+	}
+
+	if expansionType := volumeExpansion.GetType(); expansionType != csi.PluginCapability_VolumeExpansion_OFFLINE {
+		t.Fatalf("Got %v capability", expansionType)
+	}
+
+	service = resp.GetCapabilities()[3].GetService()
 	if service == nil {
 		t.Fatalf("Got nil capability service")
 	}
 
 	if serviceType := service.GetType(); serviceType != csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS {
-		t.Fatalf("Got %v capability service, want %v", serviceType, csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS)
+		t.Fatalf("Got %v capability service", serviceType)
 	}
 }
 

--- a/pkg/csi_driver/lustre_driver.go
+++ b/pkg/csi_driver/lustre_driver.go
@@ -95,6 +95,7 @@ func NewLustreDriver(config *LustreDriverConfig) (*LustreDriver, error) {
 	if config.RunController {
 		csc := []csi.ControllerServiceCapability_RPC_Type{
 			csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
+			csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 		}
 		driver.addControllerServiceCapabilities(csc)
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -164,3 +164,7 @@ func GetRegionFromZone(location string) (string, error) {
 
 	return strings.Join(tokens[0:2], "-"), nil
 }
+
+func BytesToGib(bytes int64) int64 {
+	return bytes / Gib
+}

--- a/test/k8s-integration/config/storage-class.yaml
+++ b/test/k8s-integration/config/storage-class.yaml
@@ -18,6 +18,7 @@ metadata:
   name: lustre-sc
 provisioner: lustre.csi.storage.gke.io
 volumeBindingMode: Immediate
+allowVolumeExpansion: true
 allowedTopologies:
   - matchLabelExpressions:
     - key: "topology.gke.io/zone"


### PR DESCRIPTION
This commit adds the ability to expand Lustre volumes.

The following changes are included:
- Added UpdateInstance to the Lustre service to support updating the capacity of a Lustre instance.
- Implemented ControllerExpandVolume in the CSI controller to handle volume expansion requests.
- Added EXPAND_VOLUME to the controller service capabilities.
- Updated/Added unit tests

Fixes #186 