### PR TITLE
Update getRequestCapacity logic

### DIFF
--- a/pkg/csi_driver/controller_test.go
+++ b/pkg/csi_driver/controller_test.go
@@ -441,7 +441,7 @@ func TestGetRequestCapacity(t *testing.T) {
 			capRange: &csi.CapacityRange{
 				RequiredBytes: MinVolumeSizeBytes - 1,
 			},
-			expectCap: MinVolumeSizeBytes,
+			expectCap: MinVolumeSizeBytes - 1,
 		},
 		{
 			name: "required bytes greater than minimum",
@@ -449,6 +449,13 @@ func TestGetRequestCapacity(t *testing.T) {
 				RequiredBytes: MinVolumeSizeBytes + 1,
 			},
 			expectCap: MinVolumeSizeBytes + 1,
+		},
+		{
+			name: "required bytes is not set",
+			capRange: &csi.CapacityRange{
+				LimitBytes: MinVolumeSizeBytes + 1,
+			},
+			expectCap: MinVolumeSizeBytes,
 		},
 	}
 


### PR DESCRIPTION
Changes include - 

1. Remove logic to default size to minimum size if the request is too small.
2. If RequiredBytes is not set, default to minimum size.
3. Updated unit tests