### PR TITLE
fix gcloud: Correctly parse project ID from command output

### DIFF
--- a/test/k8s-integration/cluster.go
+++ b/test/k8s-integration/cluster.go
@@ -253,5 +253,6 @@ func getCurrProject() (string, error) {
 	if projectID == "" {
 		return "", fmt.Errorf("parsed empty project ID from gcloud output: %q", string(project))
 	}
+
 	return projectID, nil
 }


### PR DESCRIPTION
The `gcloud config get-value project` command can print extra
info lines before the actual project ID, such as the active
configuration.

This change updates the parsing logic to always take the last line
of the output, ensuring the correct project ID is returned.