### PR TITLE
Enable dependabot for helm images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,7 @@ updates:
         - "sigs.k8s.io*"
         - "github.com/kubernetes-csi*"
   open-pull-requests-limit: 10
+- package-ecosystem: "helm"
+  directory: "/helm/lustre-csi-driver"
+  schedule:
+    interval: "weekly"


### PR DESCRIPTION
References
https://github.blog/changelog/2025-04-09-dependabot-version-updates-now-support-helm/
https://github.com/dependabot/dependabot-core/issues/12121