### PR TITLE
Fix stdlib cve by upgrgrading to debian-base bookworm-v1.0.6-gke.1

### DIFF
--- a/cmd/csi_driver/Dockerfile
+++ b/cmd/csi_driver/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /go/src/github.com/GoogleCloudPlatform/lustre-csi-driver
 ADD . .
 RUN make driver GOARCH=${TARGETARCH} BINDIR=/bin
 
-FROM gke.gcr.io/debian-base:bookworm-v1.0.5-gke.12 AS debian
+FROM gke.gcr.io/debian-base:bookworm-v1.0.6-gke.1 AS debian
 ENV DEBIAN_FRONTEND=noninteractive
 ARG TARGETPLATFORM
 

--- a/cmd/kmod_installer/Dockerfile
+++ b/cmd/kmod_installer/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gke.gcr.io/debian-base:bookworm-v1.0.5-gke.12
+FROM gke.gcr.io/debian-base:bookworm-v1.0.6-gke.1
 
 # Set non-interactive mode for apt to prevent prompts
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Fixes the following cves:

CVE-2025-61725, CVE-2025-47907, CVE-2025-58188, CVE-2025-61723, CVE-2025-58189, CVE-2025-58186, CVE-2025-47906, CVE-2025-61724, CVE-2025-58187, CVE-2025-58185, CVE-2025-47912, CVE-2025-58183

By upgrading the based debian versions from v1.0.5-gke.12 to v1.0.6-gke.1

Link to vulnerable image https://pantheon.corp.google.com/artifacts/docker/gke-release-staging/us/gcr.io/lustre-kmod-installer/sha256:dd9d6c7dc1806eb03d448b171bf3b0795455d5c85d85d51b712fbe263680c9db;tab=vulnerabilities?e=13802955&mods=logs_tg_prod&pageState=(%22ar-vulnerabilities%22:(%22f%22:%22%255B%257B_22k_22_3A_22Fix%2520available_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22Yes_5C_22_22%257D%255D%22))
