### PR TITLE
Automated cherry pick of #238: Fix stdlib cve by upgrgrading to debian-base bookworm-v1.0.6-gke.1

### DIFF
--- a/cmd/csi_driver/Dockerfile
+++ b/cmd/csi_driver/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /go/src/github.com/GoogleCloudPlatform/lustre-csi-driver
 ADD . .
 RUN make driver GOARCH=${TARGETARCH} BINDIR=/bin
 
-FROM gke.gcr.io/debian-base:bookworm-v1.0.5-gke.11 AS debian
+FROM gke.gcr.io/debian-base:bookworm-v1.0.6-gke.1 AS debian
 ENV DEBIAN_FRONTEND=noninteractive
 ARG TARGETPLATFORM
 

--- a/cmd/kmod_installer/Dockerfile
+++ b/cmd/kmod_installer/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gke.gcr.io/debian-base:bookworm-v1.0.5-gke.11
+FROM gke.gcr.io/debian-base:bookworm-v1.0.6-gke.1
 
 # Set non-interactive mode for apt to prevent prompts
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Cherry pick of #238 on release-0.3.

#238: Fix stdlib cve by upgrgrading to debian-base bookworm-v1.0.6-gke.1

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```