### PR TITLE
Add Table ID routing logic and validation For MultiNic feature.

### DIFF
--- a/deploy/base/controller/controller.yaml
+++ b/deploy/base/controller/controller.yaml
@@ -136,7 +136,6 @@ spec:
             - "--nodeid=$(KUBE_NODE_NAME)"
             - "--controller=true"
             - "--lustre-endpoint=$(ENDPOINT)"
-            - "--enable-legacy-lustre-port=true"
           ports:
             - containerPort: 29633
               name: healthz

--- a/deploy/base/node/node_setup.yaml
+++ b/deploy/base/node/node_setup.yaml
@@ -25,3 +25,25 @@ metadata:
 value: 900001000
 globalDefault: false
 description: "This priority class should be used for the Lustre CSI driver node deployment only."
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: lustre-csi-node-getter
+rules:
+- apiGroups: [""] # The core API group
+  resources: ["nodes"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: lustre-csi-node-sa-node-getter-binding
+subjects:
+- kind: ServiceAccount
+  name: lustre-csi-node-sa
+  namespace: lustre-csi-driver # Assuming the ServiceAccount is in this namespace
+roleRef:
+  kind: ClusterRole
+  name: lustre-csi-node-getter
+  apiGroup: rbac.authorization.k8s.io

--- a/pkg/csi_driver/lustre_driver.go
+++ b/pkg/csi_driver/lustre_driver.go
@@ -39,6 +39,8 @@ type LustreDriverConfig struct {
 	MetadataService        metadata.Service
 	Cloud                  *lustre.Cloud
 	EnableLegacyLustrePort bool
+	IsMultiNic             bool
+	AdditionalNics         []string
 }
 
 type LustreDriver struct {

--- a/pkg/k8sclient/node.go
+++ b/pkg/k8sclient/node.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sclient
+
+import (
+	"context"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+)
+
+// GetNodeWithRetry returns node information via node name.
+func GetNodeWithRetry(ctx context.Context, nodeName string) (*v1.Node, error) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	kubeClient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return getNodeWithRetry(ctx, kubeClient, nodeName)
+}
+
+func getNodeWithRetry(ctx context.Context, kubeClient *kubernetes.Clientset, nodeName string) (*v1.Node, error) {
+	var nodeObj *v1.Node
+	backoff := wait.Backoff{
+		Duration: 1 * time.Second,
+		Factor:   2.0,
+		Steps:    5,
+	}
+	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(_ context.Context) (bool, error) {
+		node, err := kubeClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			klog.Warningf("Error getting node %s: %v, retrying...", nodeName, err)
+
+			return false, nil
+		}
+		nodeObj = node
+		klog.V(4).Infof("Successfully retrieved node info %s", nodeName)
+
+		return true, nil
+	})
+	if err != nil {
+		klog.Errorf("Failed to get node %s after retries: %v", nodeName, err)
+	}
+
+	return nodeObj, err
+}

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -17,17 +17,25 @@ limitations under the License.
 package network
 
 import (
+	"context"
 	"fmt"
+	"net"
+	"os"
+	"strconv"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/lustre-csi-driver/pkg/k8sclient"
 	"github.com/vishvananda/netlink"
 	"k8s.io/klog/v2"
 )
 
 const (
 	multiRailLabel = "lustre.csi.storage.gke.io/multi-rail"
+	// max user specified table ID is 252. 253, 254, and 255 are reserved (default, main, local).
+	maxTableID = 252
 )
 
+// GetGvnicNames gets all available nics on the node.
 func GetGvnicNames() ([]string, error) {
 	links, err := netlink.LinkList()
 	if err != nil {
@@ -46,13 +54,170 @@ func GetGvnicNames() ([]string, error) {
 	return ethNics, nil
 }
 
-func ConfigureRoute() error {
-	// TODO(halimsam): Add Route configuration logic for Nics.
+func configureRoutesForNic(nicName string, nicIPAddr net.IP, instanceIPAddr string, tableID int) error {
+	// Get the network interface handle
+	link, err := netlink.LinkByName(nicName)
+	if err != nil {
+		return fmt.Errorf("failed to get interface %s: %w", nicName, err)
+	}
+
+	// Find the gateway for this interface
+	routes, err := netlink.RouteList(link, netlink.FAMILY_V4)
+	if err != nil {
+		return fmt.Errorf("failed to list routes for %s: %w", nicName, err)
+	}
+
+	var gateway net.IP
+	for _, r := range routes {
+		if r.Gw != nil {
+			gateway = r.Gw
+
+			break
+		}
+	}
+
+	if gateway == nil {
+		return fmt.Errorf("could not find gateway for %s", nicName)
+	}
+	klog.Infof("Found gateway %s for %s", gateway.String(), nicName)
+
+	// Define and add the route
+	// This is the IP of the Lustre instance which is passed in through volumeContext.
+	instanceIPAddr += "/32"
+	_, dst, _ := net.ParseCIDR(instanceIPAddr)
+	route := &netlink.Route{
+		LinkIndex: link.Attrs().Index,
+		Dst:       dst, // lustre ip
+		Gw:        gateway,
+		Table:     tableID,
+	}
+	if err := netlink.RouteReplace(route); err != nil {
+		return fmt.Errorf("failed to replace/add route for %s: %w", nicName, err)
+	}
+	klog.Infof("Successfully added (or replace) route for %s", nicName)
+
+	// Define and add the rule
+	rule := netlink.NewRule()
+	rule.Table = tableID
+	rule.Src = &net.IPNet{IP: nicIPAddr, Mask: net.CIDRMask(32, 32)} // /32 mask for a single IP
+	if err := netlink.RuleAdd(rule); err != nil {
+		if os.IsExist(err) {
+			klog.V(4).Infof("Rule for %s already exists in table %d, skipping.", nicName, tableID)
+		} else {
+			return fmt.Errorf("failed to add rule for %s: %w", nicName, err)
+		}
+	}
+	klog.Infof("Successfully added rule for %s", nicName)
+
 	return nil
 }
 
-func IsMultiRailEnabled(nodeID string) (bool, error) {
+// ConfigureRoute configures route between Lustre Instance and NIC on an available Table ID.
+func ConfigureRoute(nicName string, instanceIP string, tableID int) error {
+	nicIPAddr, err := GetNicIPAddr(nicName)
+	if err != nil {
+		return err
+	}
+
+	if err := configureRoutesForNic(nicName, nicIPAddr, instanceIP, tableID); err != nil {
+		return fmt.Errorf("failed to configure routes for %s: %w", nicName, err)
+	}
+
+	return nil
+}
+
+// GetNicIPAddr gets primary IP Address of NIC.
+func GetNicIPAddr(nicName string) (net.IP, error) {
+	link, err := netlink.LinkByName(nicName)
+	if err != nil {
+		return nil, fmt.Errorf("could not get link for %s: %w", nicName, err)
+	}
+	addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
+	if err != nil || len(addrs) == 0 {
+		return nil, fmt.Errorf("could not get address for %s: %w", nicName, err)
+	}
+	klog.Infof("Nic %v IP address are: %+v", nicName, addrs)
+
+	// We capture primary IP address which is at index 0.
+	return addrs[0].IP, nil
+}
+
+// IsMultiRailEnabled checks for Multi Nic feature via node label.
+func IsMultiRailEnabled(ctx context.Context, nodeID string, nics []string) (bool, error) {
 	klog.V(4).Infof("Checking if node label %s exists in %s", multiRailLabel, nodeID)
-	// TODO(halimsam): Add Multi Rail Logic check here.
+	if len(nics) <= 1 {
+		klog.V(4).Infof("Node only has 1 nic or less available. Not suitable for Multi-Nic feature. current nics: %v", nics)
+
+		return false, nil
+	}
+	node, err := k8sclient.GetNodeWithRetry(ctx, nodeID)
+	if err != nil {
+		return false, err
+	}
+
+	if val, found := node.GetLabels()[multiRailLabel]; found {
+		isMultiNicEnabled, err := strconv.ParseBool(val)
+		if err != nil {
+			return false, err
+		}
+		klog.Infof("Node: %v, MultiNic Enabled: %v", nodeID, isMultiNicEnabled)
+
+		return isMultiNicEnabled, nil
+	}
+
 	return false, nil
+}
+
+func isTableFree(tableID int, targetIP net.IP) (bool, error) {
+	// Check if any active Policy Rules point to this table
+	rules, err := netlink.RuleList(netlink.FAMILY_V4)
+	if err != nil {
+		return false, fmt.Errorf("failed to list rules: %w", err)
+	}
+	for _, r := range rules {
+		if r.Table == tableID {
+			// Check if Table is already assigned to an existing NIC.
+			if r.Src != nil && r.Src.IP.Equal(targetIP) {
+				klog.V(4).Infof("Table %d is already assigned to IP %s. Reusing it.", tableID, targetIP.String())
+
+				return true, nil
+			}
+			klog.V(5).Infof("Table %d is occupied by a rule for a different Src IP.", tableID)
+
+			return false, nil
+		}
+	}
+
+	// Check if any Routes exist in this table
+	filter := &netlink.Route{Table: tableID}
+	mask := netlink.RT_FILTER_TABLE
+	routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, filter, mask)
+	if err != nil {
+		return false, fmt.Errorf("failed to list routes for table %d: %w", tableID, err)
+	}
+
+	if len(routes) > 0 {
+		klog.V(5).Infof("Table %d is occupied by %d routes. Checking next table ID.", tableID, len(routes))
+
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// FindNextFreeTableID finds available Table ID for NIC confiugration.
+func FindNextFreeTableID(startID int, nicIPAddr net.IP) (int, error) {
+	for id := startID; id <= maxTableID; id++ {
+		usable, err := isTableFree(id, nicIPAddr)
+		if err != nil {
+			return 0, err
+		}
+		if usable {
+			klog.Infof("Found free routing table ID: %d", id)
+
+			return id, nil
+		}
+	}
+
+	return 0, fmt.Errorf("no free routing tables found between %d and %d", startID, maxTableID)
 }


### PR DESCRIPTION
This change introduces validation and routing configuration for MultiNic. MultiNic is enabled by node label `lustre.csi.storage.gke.io/multi-rail=true`.  If enabled,  we add all the NICs as lnet network parameters during kmod install. When a lustre instance is created, attached to a pod, and the pod is scheduled to a node with MultiNic enabled: we configure routes for the NIC and Lustre instance on the Table ID.  Each available NIC (except for default nic0) will be paired to a unique Table ID and routes will be configured to all Nic's Table ID for each Lustre instance. You can also create the nodepool node label directly, eliminating the need to update them after node creation.

This diagram below shows the routing table when NodeStageVolume is called with MultiNic logic.

Diagram:
<img width="611" height="611" alt="image" src="https://github.com/user-attachments/assets/f2823d72-aec5-4027-8509-bc51c08dd1c1" />


Successful lustre CSI setup:
<img width="1123" height="227" alt="image" src="https://github.com/user-attachments/assets/763a0300-9ba9-4d38-a750-1602e72313ee" />

successful routing logs setup for nics during mounting (NodeStageVolume):
<img width="3330" height="1726" alt="image" src="https://github.com/user-attachments/assets/5ad1900f-d0f1-480a-ae1a-d4b574d98bd7" />


Pod running (using dynamic-pvc.yaml and dynamic-pod.yaml):
<img width="583" height="66" alt="image" src="https://github.com/user-attachments/assets/8d850bd9-cb3c-49a4-b9d0-4b522b1b6ce2" />



**For testing:**
I created my own network with lustre setup, and added a non-overlap subnet for the additional nic (multinic-subnet)

1. I created a cluster/nodepool with multiple VPC/subnet to have multi nics:
```
gcloud container clusters create single-vpc \ --location=us-central1-c \ --num-nodes=1 \ --network=samhalim-network \ --cluster-version=1.34.1-gke.2541000 --enable-kernel-module-signature-enforcement
```

2. Create custom network with subnet:
```
gcloud container clusters create single-vpc --location=us-central1-c --num-nodes=1 --network=samhalim-network --cluster-version=1.34.1-gke.2541000 --enable-kernel-module-signature-enforcement
```

3. Create nodepool with multi nic
```
gcloud container node-pools create single-vpc --cluster=single-vpc --num-nodes=1 --zone=us-central1-c --additional-node-network network=samhalim-network,subnetwork=multinic-subnet --enable-kernel-module-signature-enforcement
```

4. Add multi-rail node label to node with multi nics (eth0, eth1):
```
kubectl label node <NODE_NAME> lustre.csi.storage.gke.io/multi-rail=true
```
