### PR TITLE
Add disable loadpin logic in Lustre csi driver

### DIFF
--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -69,6 +69,9 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	if !*disableKmodInstall {
+		if err := kmod.DisableLoadPin(ctx); err != nil {
+			klog.Fatalf("Disable LoadPin failure: %v", err)
+		}
 		if err := kmod.InstallLustreKmod(ctx, *nodeID, *enableLegacyLustrePort, dkmsArgsOverride); err != nil {
 			klog.Fatalf("Kmod install failure: %v", err)
 		}

--- a/deploy/base/node/node.yaml
+++ b/deploy/base/node/node.yaml
@@ -68,6 +68,8 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
+            - name: dev
+              mountPath: /dev
             - name: kubelet-dir
               mountPath: /var/lib/kubelet
               mountPropagation: "Bidirectional"


### PR DESCRIPTION
One of my recent change #227  combined Kmod Installer bash script into Lustre csi driver. This did not include disabling loadpin, adding it in this PR.

