### PR TITLE
[POC] [DO NOT MERGE] Implement Virtual Global Mount for IAM-enabled Volumes

### DIFF
--- a/deploy/base/node/node.yaml
+++ b/deploy/base/node/node.yaml
@@ -69,6 +69,9 @@ spec:
             - name: kubelet-dir
               mountPath: /var/lib/kubelet
               mountPropagation: "Bidirectional"
+            - name: lustre-dir
+              mountPath: /var/lib/lustre
+              mountPropagation: "Bidirectional"
             - name: socket-dir
               mountPath: /csi
             - name: host-etc
@@ -108,6 +111,10 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins_registry/
             type: Directory
+        - name: lustre-dir
+          hostPath:
+            path: /var/lib/lustre
+            type: DirectoryOrCreate
         - name: kubelet-dir
           hostPath:
             path: /var/lib/kubelet

--- a/deploy/base/setup/csi_driver.yaml
+++ b/deploy/base/setup/csi_driver.yaml
@@ -18,3 +18,7 @@ metadata:
   name: lustre.csi.storage.gke.io
 spec:
   attachRequired: false
+  podInfoOnMount: true
+  requiresRepublish: true
+  tokenRequests:
+  - audience: tyuchn-joonix.svc.id.goog

--- a/examples/pre-prov/preprov-pod.yaml
+++ b/examples/pre-prov/preprov-pod.yaml
@@ -26,4 +26,4 @@ spec:
   volumes:
    - name: mypvc
      persistentVolumeClaim:
-       claimName: preprov-pvc
+       claimName: preprov-pvc-iam

--- a/examples/pre-prov/preprov-pvc-pv.yaml
+++ b/examples/pre-prov/preprov-pvc-pv.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: preprov-pv
+  name: preprov-pv-iam
 spec:
   storageClassName: ""
   capacity:
@@ -26,26 +26,27 @@ spec:
   volumeMode: Filesystem
   claimRef:
     namespace: default
-    name: preprov-pvc
+    name: preprov-pvc-iam
   csi:
     driver: lustre.csi.storage.gke.io
-    volumeHandle: <project-id>/<instance-location>/<instance-name> # Modify this to use the project, zone, and mananged lustre instance name.
+    volumeHandle: my-instance-iam # Modify this to use the project, zone, and mananged lustre instance name.
     volumeAttributes:
-      ip: ${EXISTING_LUSTRE_IP_ADDRESS} # The IP address of the existing Lustre instance.
-      filesystem: ${EXISTING_LUSTRE_FSNAME} # The filesystem name of the existing Lustre instance.
+      ip: 172.17.1.6 # The IP address of the existing Lustre instance.
+      filesystem: testlfs # The filesystem name of the existing Lustre instance.
       # Alternatively, you can use mountpoint:
       # mountpoint: ${EXISTING_LUSTRE_IP_ADDRESS}@tcp:/${EXISTING_LUSTRE_FSNAME}
       # If `mountpoint` is provided, it will override `ip` and `filesystem`.
+      access_check_type: IAM
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: preprov-pvc
+  name: preprov-pvc-iam
 spec:
   accessModes:
     - ReadWriteMany
   storageClassName: ""
-  volumeName: preprov-pv
+  volumeName: preprov-pv-iam
   resources:
     requests:
       storage: 9000Gi

--- a/examples/verify-global-mount.yaml
+++ b/examples/verify-global-mount.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: verify-sa-shared
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: verify-sa-isolated
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: verify-shared
+  labels:
+    app: verify-shared
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: verify-shared
+  template:
+    metadata:
+      labels:
+        app: verify-shared
+    spec:
+      serviceAccountName: verify-sa-shared
+      containers:
+      - name: nginx
+        image: nginx
+        volumeMounts:
+        - mountPath: /lustre_volume
+          name: mypvc
+      volumes:
+      - name: mypvc
+        persistentVolumeClaim:
+          claimName: preprov-pvc-iam
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: verify-isolated
+  labels:
+    app: verify-isolated
+spec:
+  serviceAccountName: verify-sa-isolated
+  containers:
+  - name: nginx
+    image: nginx
+    volumeMounts:
+    - mountPath: /lustre_volume
+      name: mypvc
+  volumes:
+  - name: mypvc
+    persistentVolumeClaim:
+      claimName: preprov-pvc-iam

--- a/pkg/csi_driver/controller.go
+++ b/pkg/csi_driver/controller.go
@@ -66,8 +66,9 @@ const (
 	TopologyKeyZone = "topology.gke.io/zone"
 
 	// PV Volume attributes.
-	keyInstanceIP = "ip"
-	keyMountPoint = "mountpoint"
+	keyInstanceIP      = "ip"
+	keyMountPoint      = "mountpoint"
+	keyAccessCheckType = "access_check_type"
 
 	defaultNetwork = "default"
 
@@ -89,6 +90,7 @@ var (
 		keyInstanceIP,
 		keyFilesystem,
 		keyMountPoint,
+		keyAccessCheckType,
 	}
 )
 


### PR DESCRIPTION
This PR introduces the "Virtual Global Mount" architecture for the Lustre CSI driver, specifically targeting IAM-enabled volumes. This design shifts from a per-pod mount model to a global mount shared by all pods on a node that use the same Volume and Kubernetes Service Account (KSA).