### PR TITLE
Adding fork logic setting up lustre kmod install for Ubuntu support.

### DIFF
--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -144,8 +144,22 @@ func main() {
 				klog.Fatalf("Failed to get LNET network parameters: %v", err)
 			}
 		} else if !*disableKmodInstall {
-			if err := kmod.InstallLustreKmod(ctx, *enableLegacyLustrePort, customModuleArgs, nics, effectiveDisableMultiNIC); err != nil {
-				klog.Fatalf("Kmod install failure: %v", err)
+			hostOS, err := kmod.HostOSFromNodeLabel(ctx, *nodeID, nodeClient)
+			if err != nil {
+				klog.Errorf("Failed to read OS Host Info: %v", err)
+			}
+			switch hostOS {
+			case "cos":
+				err = kmod.InstallLustreKmodOnCos(ctx, *enableLegacyLustrePort, customModuleArgs, nics, effectiveDisableMultiNIC)
+				if err != nil {
+					klog.Fatalf("Failed to install lustre kernel modules on COS: %v", err)
+				}
+			case "ubuntu":
+				// TODO(samhalim): Add function for kmod install on Ubuntu Nodes
+			case "windows":
+				klog.Warning("Lustre kernel modules are not supported on Windows nodes.")
+			default:
+				klog.Fatalf("Unsupported or unknown Host OS: %q. Canot perform Kmod Installation", hostOS)
 			}
 		}
 

--- a/pkg/kmod_installer/kmod_installer.go
+++ b/pkg/kmod_installer/kmod_installer.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoogleCloudPlatform/lustre-csi-driver/pkg/network"
 	"k8s.io/klog/v2"
 )
 
@@ -33,6 +34,7 @@ const (
 	defaultLNetPort    = 988
 	cmdTimeout         = 15 * time.Minute
 	DefaultLnetNetwork = "tcp0(eth0)"
+	osNodeLabel        = "cloud.google.com/gke-os-distribution"
 )
 
 var (
@@ -126,9 +128,9 @@ func readLnetConfig(path string) (string, error) {
 	return currNetworkNics, nil
 }
 
-// InstallLustreKmod installs the Lustre kernel modules on the node using cos-dkms.
+// InstallLustreKmodOnCos installs the Lustre kernel modules on the node using cos-dkms on COS nodes.
 // It proceeds with the installation using the provided NICs.
-func InstallLustreKmod(ctx context.Context, enableLegacyPort bool, customModuleArgs []string, nics []string, disableMultiNIC bool) error {
+func InstallLustreKmodOnCos(ctx context.Context, enableLegacyPort bool, customModuleArgs []string, nics []string, disableMultiNIC bool) error {
 	lnetPort := lnetPort(enableLegacyPort)
 	expectedNetwork := DefaultLnetNetwork
 	if !disableMultiNIC {
@@ -203,4 +205,18 @@ func parseLnetNetwork(networkStr string) []string {
 	}
 
 	return strings.Split(networkStr, ",")
+}
+
+// HostOSFromNodeLabel returns the OS identifier from node label.
+func HostOSFromNodeLabel(ctx context.Context, nodeID string, nc network.NodeClient) (string, error) {
+	node, err := nc.GetNodeWithRetry(ctx, nodeID)
+	if err != nil {
+		return "", err
+	}
+	val, found := node.GetLabels()[osNodeLabel]
+	if !found {
+		klog.Warningf("Label %v could not be found on the node", osNodeLabel)
+		return "unknown", nil
+	}
+	return val, nil
 }

--- a/pkg/kmod_installer/kmod_installer_test.go
+++ b/pkg/kmod_installer/kmod_installer_test.go
@@ -17,11 +17,15 @@ limitations under the License.
 package kmodinstaller
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestIsLustreKmodInstalled(t *testing.T) {
@@ -178,6 +182,74 @@ func TestGetLnetNetwork(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("getLnetNetwork() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+type mockNodeClient struct {
+	node *v1.Node
+	err  error
+}
+
+func (m *mockNodeClient) GetNodeWithRetry(ctx context.Context, nodeName string) (*v1.Node, error) {
+	return m.node, m.err
+}
+
+func TestHostOSFromNodeLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		mockNode *v1.Node
+		wantOS   string
+		mockErr  error
+		wantErr  bool
+	}{
+		{
+			name: "Valid label found",
+			mockNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{osNodeLabel: "cos"},
+				},
+			},
+			wantOS: "cos",
+		},
+		{
+			name: "Host OS Label missing - returns unknown",
+			mockNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"random-key": "ubuntu"},
+				},
+			},
+			wantOS: "unknown",
+		},
+		{
+			name:    "API error from k8s client",
+			mockErr: fmt.Errorf("k8s node timeout"),
+			wantOS:  "",
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := &mockNodeClient{
+				node: tc.mockNode,
+				err:  tc.mockErr,
+			}
+
+			got, err := HostOSFromNodeLabel(context.Background(), "node-name", client)
+
+			// Error check
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("HostOSFromNodeLabel() error = %v, wantErr %v", err, tc.wantErr)
+			}
+
+			// Node label value check
+			if got != tc.wantOS {
+				t.Errorf("HostOSFromNodeLabel() got = %v, want %v", got, tc.wantOS)
 			}
 		})
 	}

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -55,7 +55,7 @@ type netlinker interface {
 	GetStandardNICs() ([]string, error)
 }
 
-type nodeClient interface {
+type NodeClient interface {
 	GetNodeWithRetry(ctx context.Context, nodeName string) (*v1.Node, error)
 }
 
@@ -67,7 +67,7 @@ type MetadataClient interface {
 // RouteManager provides methods for network configuration using the netlinker interface.
 type RouteManager struct {
 	nl netlinker
-	nc nodeClient
+	nc NodeClient
 	mc MetadataClient
 }
 
@@ -143,11 +143,11 @@ func NewNetlink() netlinker {
 	return &realNetlink{}
 }
 
-func NewK8sClient() nodeClient {
+func NewK8sClient() NodeClient {
 	return &k8sNodeClient{}
 }
 
-func Manager(nl netlinker, nc nodeClient, mc MetadataClient) *RouteManager {
+func Manager(nl netlinker, nc NodeClient, mc MetadataClient) *RouteManager {
 	return &RouteManager{nl: nl, nc: nc, mc: mc}
 }
 


### PR DESCRIPTION
Added HostOS function to determine kmod install fork for COS and Ubuntu using node label `cloud.google.com/gke-os-distribution`