### PR TITLE
Implement Lustre Kernel Module installation on Ubuntu

### DIFF
--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -105,15 +105,19 @@ func main() {
 		klog.Info("Retrieving the network interface specified in LNET parameters.")
 		// Pass an empty string as expected network because the kmod-installer initContainer is responsible
 		// for configuring multi-NIC and loading the module. CSI driver will just read the actual config.
-		nics, err := kmod.GetLnetNetwork("")
+		nics, err := kmod.GetLnetNetwork("", hostOS)
 		if err != nil {
 			klog.Fatalf("Failed to get LNET network parameters: %v", err)
 		}
-		// additional NICs are any additional NICs that are not default (eth0).
 		// These NICs will require additional setup for multi nic feature.
+		defaultNic := "eth0"
+		if hostOS == "ubuntu" {
+			// This is an assumption we've made that Ubuntu nodes will always use ens4 as default NIC.
+			defaultNic = "ens4"
+		}
 		additionalNics := []string{}
 		for _, nic := range nics {
-			if nic != "eth0" {
+			if nic != defaultNic {
 				additionalNics = append(additionalNics, nic)
 			}
 		}

--- a/cmd/kmod_installer/Dockerfile
+++ b/cmd/kmod_installer/Dockerfile
@@ -29,7 +29,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     kmod \
     openssl \
     ca-certificates \
+    curl \
+    gpg \
     && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor --batch --yes -o /usr/share/keyrings/google-cloud.gpg && \
+    curl -fsSL https://us-apt.pkg.dev/doc/repo-signing-key.gpg | gpg --dearmor --batch --yes -o /usr/share/keyrings/lustre-client.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/google-cloud.gpg] http://packages.cloud.google.com/apt apt-transport-artifact-registry-stable main" | tee /etc/apt/sources.list.d/artifact-registry.list && \
+    apt-get update && apt-get install -y --no-install-recommends apt-transport-artifact-registry && \
+    echo "deb [signed-by=/usr/share/keyrings/lustre-client.gpg] ar+https://us-apt.pkg.dev/projects/lustre-client-binaries lustre-client-ubuntu-noble main" | tee -a /etc/apt/sources.list.d/artifact-registry.list && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY --from=gcr.io/cos-cloud/cos-dkms:v0.3.12 /usr/bin/cos-dkms /usr/bin/cos-dkms
 COPY --from=builder /bin/lustre-kmod-installer /usr/bin/lustre-kmod-installer

--- a/cmd/kmod_installer/main.go
+++ b/cmd/kmod_installer/main.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 
+	gcemetadata "cloud.google.com/go/compute/metadata"
 	"github.com/GoogleCloudPlatform/lustre-csi-driver/pkg/cloud_provider/metadata"
 	kmod "github.com/GoogleCloudPlatform/lustre-csi-driver/pkg/kmod_installer"
 	"github.com/GoogleCloudPlatform/lustre-csi-driver/pkg/network"
@@ -90,14 +91,22 @@ func main() {
 		klog.Fatalf("Lustre kernel module installation check failed: %v", err)
 	}
 
+	hostOS, err := kmod.HostOSFromNodeLabel(ctx, *nodeID, nodeClient)
+	if err != nil {
+		klog.Fatalf("Failed to read OS Host Info: %v", err)
+	}
+
 	if isInstalled {
 		// Check if the current configuration matches the expectation.
-		expectedNetwork := kmod.DefaultLnetNetwork
+		expectedNetwork := kmod.DefaultCosLnetNetwork
+		if hostOS == "ubuntu" {
+			expectedNetwork = kmod.DefaultUbuntuLnetNetwork
+		}
+
 		if !effectiveDisableMultiNIC {
 			expectedNetwork = fmt.Sprintf("tcp0(%s)", strings.Join(nics, ","))
 		}
-
-		if _, err = kmod.GetLnetNetwork(expectedNetwork); err != nil {
+		if _, err = kmod.GetLnetNetwork(expectedNetwork, hostOS); err != nil {
 			klog.Fatalf("Failed to get LNET network parameters: %v", err)
 		}
 
@@ -107,11 +116,6 @@ func main() {
 
 	klog.Info("Lustre kernel module is not installed. Proceeding with installation.")
 
-	hostOS, err := kmod.HostOSFromNodeLabel(ctx, *nodeID, nodeClient)
-	if err != nil {
-		klog.Fatalf("Failed to read OS Host Info: %v", err)
-	}
-
 	switch hostOS {
 	case "cos":
 		err = kmod.InstallLustreKmodOnCos(ctx, *enableLegacyLustrePort, customModuleArgs, nics, effectiveDisableMultiNIC)
@@ -119,7 +123,25 @@ func main() {
 			klog.Fatalf("Failed to install lustre kernel modules on COS: %v", err)
 		}
 	case "ubuntu":
-		// TODO(samhalim): Add function for kmod install on Ubuntu Nodes.
+		scopes, err := gcemetadata.ScopesWithContext(ctx, "")
+		if err != nil {
+			klog.Warningf("Failed to get service account scopes from GCE metadata: %v", err)
+		} else {
+			hasCloudPlatformScope := false
+			for _, scope := range scopes {
+				if scope == "https://www.googleapis.com/auth/cloud-platform" {
+					hasCloudPlatformScope = true
+					break
+				}
+			}
+			if !hasCloudPlatformScope {
+				klog.Fatalf("The https://www.googleapis.com/auth/cloud-platform scope is missing. This is required for installing Lustre packages from Artifact Registry")
+			}
+		}
+		err = kmod.InstallLustreKmodOnUbuntu(ctx, *enableLegacyLustrePort, customModuleArgs, nics, effectiveDisableMultiNIC)
+		if err != nil {
+			klog.Fatalf("Failed to install lustre kernel modules on Ubuntu: %v", err)
+		}
 	case "windows":
 		klog.Warning("Lustre kernel modules are not supported on Windows nodes.")
 	default:

--- a/deploy/base/node/node.yaml
+++ b/deploy/base/node/node.yaml
@@ -39,9 +39,20 @@ spec:
           type: RuntimeDefault
       priorityClassName: csi-lustre-node
       serviceAccount: lustre-csi-node-sa
-      nodeSelector:
-        kubernetes.io/os: linux
-        cloud.google.com/gke-os-distribution: cos
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+                  - key: cloud.google.com/gke-os-distribution
+                    operator: In
+                    values:
+                      - cos
+                      - ubuntu
       initContainers:
         - name: lustre-kmod-installer
           securityContext:
@@ -92,6 +103,8 @@ spec:
               mountPath: /csi
             - name: host-udev
               mountPath: /host_etc_udev
+            - name: dev
+              mountPath: /dev
         - name: csi-driver-registrar
           securityContext:
             readOnlyRootFilesystem: true
@@ -143,6 +156,10 @@ spec:
         - name: host-udev
           hostPath:
             path: /etc/udev
+            type: Directory
+        - name: dev
+          hostPath:
+            path: /dev
             type: Directory
       # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
       # See "special case". This will tolerate everything. Node component should

--- a/pkg/kmod_installer/kmod_installer.go
+++ b/pkg/kmod_installer/kmod_installer.go
@@ -30,16 +30,18 @@ import (
 )
 
 const (
-	legacyLNetPort     = 6988
-	defaultLNetPort    = 988
-	cmdTimeout         = 15 * time.Minute
-	DefaultLnetNetwork = "tcp0(eth0)"
-	osNodeLabel        = "cloud.google.com/gke-os-distribution"
+	legacyLNetPort           = 6988
+	defaultLNetPort          = 988
+	cmdTimeout               = 15 * time.Minute
+	DefaultCosLnetNetwork    = "tcp0(eth0)"
+	DefaultUbuntuLnetNetwork = "tcp0(ens4)"
+	osNodeLabel              = "cloud.google.com/gke-os-distribution"
 )
 
 var (
 	lnetAcceptPortFile       = "/sys/module/lnet/parameters/accept_port"
 	lnetNetworkParameterFile = "/sys/module/lnet/parameters/networks"
+	lustreModuleDir          = "/sys/module/lustre"
 )
 
 func lnetPort(enableLegacyLustrePort bool) int {
@@ -58,10 +60,10 @@ func lnetPort(enableLegacyLustrePort bool) int {
 // Returns (false, nil) if not installed.
 // Returns (false, error) if unexpected filesystem error checking the file.
 func IsLustreKmodInstalled(enableLegacyLustrePort bool) (bool, error) {
-	return isLustreKmodInstalled(enableLegacyLustrePort, lnetAcceptPortFile)
+	return isLustreKmodInstalled(enableLegacyLustrePort, lnetAcceptPortFile, lustreModuleDir)
 }
 
-func isLustreKmodInstalled(enableLegacyLustrePort bool, acceptPortFile string) (bool, error) {
+func isLustreKmodInstalled(enableLegacyLustrePort bool, acceptPortFile, lustreModuleDir string) (bool, error) {
 	// Check if the kernel module is loaded by checking the existence of the parameter file
 	file, err := os.ReadFile(acceptPortFile)
 	if err != nil {
@@ -70,6 +72,13 @@ func isLustreKmodInstalled(enableLegacyLustrePort bool, acceptPortFile string) (
 		}
 
 		return false, fmt.Errorf("failed to read lnet accept port file %s: %w", acceptPortFile, err)
+	}
+
+	if _, err := os.Stat(lustreModuleDir); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check lustre module sysfs: %w", err)
 	}
 
 	currPort := strings.TrimSpace(string(file))
@@ -88,17 +97,20 @@ func isLustreKmodInstalled(enableLegacyLustrePort bool, acceptPortFile string) (
 // It reads the "networks" parameter from the LNet module parameters.
 // If expectedNics is provided, it validates the current config matches expectation and warns on mismatch.
 // If the file is missing but modules are installed, it returns a default "eth0".
-func GetLnetNetwork(expectedNics string) ([]string, error) {
-	return getLnetNetwork(expectedNics, lnetNetworkParameterFile)
+func GetLnetNetwork(expectedNics, hostOS string) ([]string, error) {
+	return getLnetNetwork(expectedNics, lnetNetworkParameterFile, hostOS)
 }
 
-func getLnetNetwork(expectedNics, networkFile string) ([]string, error) {
-	networkStr, err := readLnetConfig(networkFile)
+func getLnetNetwork(expectedNics, networkFile, hostOS string) ([]string, error) {
+	networkStr, err := readLnetConfig(networkFile, hostOS)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// If the LNET parameter file is missing but modules are supposedly installed,
-			// falling back to a (tcp0(eth0)) as the default.
-			networkStr = DefaultLnetNetwork
+			// falling back to a (tcp0(eth0)) / (tcp0(ens4)) as the default.
+			networkStr = DefaultCosLnetNetwork
+			if hostOS == "ubuntu" {
+				networkStr = DefaultUbuntuLnetNetwork
+			}
 		} else {
 			return nil, err
 		}
@@ -111,7 +123,7 @@ func getLnetNetwork(expectedNics, networkFile string) ([]string, error) {
 	return parseLnetNetwork(networkStr), nil
 }
 
-func readLnetConfig(path string) (string, error) {
+func readLnetConfig(path, hostOS string) (string, error) {
 	file, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
@@ -122,7 +134,10 @@ func readLnetConfig(path string) (string, error) {
 		// An empty lnetNetworkParameterFile implies either the kernel modules are not installed yet,
 		// or they are installed, but just without any parameters.
 		// If that file is empty, but kernel modules are already installed, eth0 should be used.
-		return DefaultLnetNetwork, nil
+		if hostOS == "ubuntu" {
+			return DefaultUbuntuLnetNetwork, nil
+		}
+		return DefaultCosLnetNetwork, nil
 	}
 
 	return currNetworkNics, nil
@@ -132,7 +147,7 @@ func readLnetConfig(path string) (string, error) {
 // It proceeds with the installation using the provided NICs.
 func InstallLustreKmodOnCos(ctx context.Context, enableLegacyPort bool, customModuleArgs []string, nics []string, disableMultiNIC bool) error {
 	lnetPort := lnetPort(enableLegacyPort)
-	expectedNetwork := DefaultLnetNetwork
+	expectedNetwork := DefaultCosLnetNetwork
 	if !disableMultiNIC {
 		expectedNetwork = fmt.Sprintf("tcp0(%s)", strings.Join(nics, ","))
 	}
@@ -192,6 +207,124 @@ func InstallLustreKmodOnCos(ctx context.Context, enableLegacyPort bool, customMo
 	}
 
 	klog.Infof("COS-DKMS output:\n%s\n", string(output))
+
+	return nil
+}
+
+// InstallLustreKmodOnUbuntu installs the Lustre kernel modules on Ubuntu nodes.
+func InstallLustreKmodOnUbuntu(ctx context.Context, enableLegacyPort bool, customModuleArgs []string, nics []string, disableMultiNIC bool) error {
+	lnetPort := lnetPort(enableLegacyPort)
+	expectedNetwork := DefaultUbuntuLnetNetwork
+	if len(nics) > 0 && !disableMultiNIC {
+		expectedNetwork = fmt.Sprintf("tcp0(%s)", strings.Join(nics, ","))
+	}
+
+	cmdCtx, cancel := context.WithTimeout(ctx, cmdTimeout)
+	defer cancel()
+
+	uname := exec.CommandContext(cmdCtx, "uname", "-r")
+	unameOut, err := uname.Output()
+	if err != nil {
+		return fmt.Errorf("failed to determine kernel version via uname -r: %w", err)
+	}
+	kernelVersion := strings.TrimSpace(string(unameOut))
+	klog.Infof("Detected target Ubuntu kernel version: %s", kernelVersion)
+
+	updateCmd := exec.CommandContext(cmdCtx, "apt-get", "update")
+	if out, err := updateCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to update apt repositories: %w\noutput:\n%s", err, string(out))
+	}
+
+	// download lustre client packages
+	moduleName := fmt.Sprintf("lustre-client-modules-%s/lustre-client-ubuntu-noble", kernelVersion)
+	tmpDir, err := os.MkdirTemp("", "lustre-kmod-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp driectory: %w", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			klog.Warningf("Failed to remove temp directory %s: %v", tmpDir, err)
+		}
+	}()
+
+	klog.Infof("Downloading lustre client modules, package: %v, into: %v", moduleName, tmpDir)
+	downloadCmd := exec.CommandContext(cmdCtx, "apt-get", "download", moduleName)
+	downloadCmd.Dir = tmpDir
+	if out, err := downloadCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to download lustre client modules: %w\noutput:\n%s", err, string(out))
+	}
+
+	// confirm .deb file is present
+	files, err := os.ReadDir(tmpDir)
+	if err != nil {
+		return fmt.Errorf("failed to read download directory: %w", err)
+	}
+	var debFile string
+	for _, f := range files {
+		if !f.IsDir() && strings.HasSuffix(f.Name(), ".deb") {
+			debFile = f.Name()
+			break
+		}
+	}
+	if debFile == "" {
+		return fmt.Errorf("no .deb file found in %v", tmpDir)
+	}
+	klog.Infof("Found lustre client modules deb file: %v", debFile)
+
+	// extract deb file package locally
+	extractDir, err := os.MkdirTemp("", "extracted-kmod-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp extract directory: %w", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(extractDir); err != nil {
+			klog.Warningf("Failed to remove temp extract directory %s: %v", extractDir, err)
+		}
+	}()
+
+	extractCmd := exec.CommandContext(cmdCtx, "dpkg", "-x", tmpDir+"/"+debFile, extractDir)
+	if out, err := extractCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("dpkg -x failed: %w\noutput:\n%s", err, string(out))
+	}
+
+	klog.Infof("Running depmod for extracted modules in basedir %s", extractDir)
+	depmodCmd := exec.CommandContext(cmdCtx, "depmod", "-b", extractDir, kernelVersion)
+	if out, err := depmodCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("depmod failed: %w\noutput:\n%s", err, string(out))
+	}
+	lnetArgs := []string{"-d", extractDir, "lnet", fmt.Sprintf("accept_port=%d", lnetPort), fmt.Sprintf("networks=%s", expectedNetwork)}
+	for _, arg := range customModuleArgs {
+		if strings.HasPrefix(arg, "lnet.") {
+			lnetArgs = append(lnetArgs, strings.TrimPrefix(arg, "lnet."))
+		}
+	}
+
+	klog.Infof("Loading lnet module explicitly via modprobe with args: %v", lnetArgs)
+	lnetCmd := exec.CommandContext(cmdCtx, "modprobe", lnetArgs...)
+	if out, err := lnetCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("modprobe lnet failed: %w\noutput:\n%s", err, string(out))
+	}
+
+	// Load the underlying TCP network driver (ksocklnd), core lustre module,
+	// and required client subsystem modules (mgc: management, lmv/mdc: metadata, lov/osc: object storage)
+	// via modprobe to ensure they are resident in kernel memory before the ephemeral module files are removed.
+	clientModules := []string{"ksocklnd", "lustre", "mgc", "lmv", "lov", "mdc", "osc"}
+	for _, mod := range clientModules {
+		modArgs := []string{"-d", extractDir, mod}
+		prefix := mod + "."
+		for _, arg := range customModuleArgs {
+			if strings.HasPrefix(arg, prefix) {
+				modArgs = append(modArgs, strings.TrimPrefix(arg, prefix))
+			}
+		}
+		klog.Infof("Loading %s module via modprobe with args: %v", mod, modArgs)
+		cmd := exec.CommandContext(cmdCtx, "modprobe", modArgs...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("modprobe %s failed: %w\noutput:\n%s", mod, err, string(out))
+		}
+	}
+
+	klog.Infof("Ubuntu Lustre installation completed successfully.")
 
 	return nil
 }

--- a/pkg/kmod_installer/kmod_installer_test.go
+++ b/pkg/kmod_installer/kmod_installer_test.go
@@ -35,6 +35,7 @@ func TestIsLustreKmodInstalled(t *testing.T) {
 		name             string
 		fileContent      string
 		fileMissing      bool
+		lustreDirMissing bool
 		isDir            bool
 		enableLegacyPort bool
 		wantInstalled    bool
@@ -45,6 +46,13 @@ func TestIsLustreKmodInstalled(t *testing.T) {
 			fileMissing:   true,
 			wantInstalled: false,
 			wantErr:       false,
+		},
+		{
+			name:             "accept_port exists but lustre module dir missing",
+			fileContent:      "988",
+			lustreDirMissing: true,
+			wantInstalled:    false,
+			wantErr:          false,
 		},
 		{
 			name:             "File exists, default port match",
@@ -88,6 +96,13 @@ func TestIsLustreKmodInstalled(t *testing.T) {
 			t.Parallel()
 			tempDir := t.TempDir()
 			acceptPortFile := filepath.Join(tempDir, "accept_port")
+			lustreModuleDir := filepath.Join(tempDir, "lustre")
+
+			if !tc.lustreDirMissing {
+				if err := os.Mkdir(lustreModuleDir, 0o755); err != nil {
+					t.Fatalf("Failed to create temp lustre dir: %v", err)
+				}
+			}
 
 			if !tc.fileMissing {
 				if tc.isDir {
@@ -101,7 +116,7 @@ func TestIsLustreKmodInstalled(t *testing.T) {
 				}
 			}
 
-			gotInstalled, err := isLustreKmodInstalled(tc.enableLegacyPort, acceptPortFile)
+			gotInstalled, err := isLustreKmodInstalled(tc.enableLegacyPort, acceptPortFile, lustreModuleDir)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("isLustreKmodInstalled() error = %v, wantErr %v", err, tc.wantErr)
 			}
@@ -120,46 +135,66 @@ func TestGetLnetNetwork(t *testing.T) {
 		fileContent  string
 		fileMissing  bool
 		expectedNics string
+		hostOS       string
 		want         []string
 		// We don't check for specific log output here, but we verify the return values
 		// and that it doesn't crash on warnings.
 	}{
 		{
-			name:        "File missing - returns default eth0",
+			name:        "File missing - returns default eth0 on cos",
 			fileMissing: true,
+			hostOS:      "cos",
 			want:        []string{"eth0"},
 		},
 		{
-			name:        "File empty - returns default eth0",
+			name:        "File missing - returns default ens4 on ubuntu",
+			fileMissing: true,
+			hostOS:      "ubuntu",
+			want:        []string{"ens4"},
+		},
+		{
+			name:        "File empty - returns default eth0 on cos",
 			fileContent: "",
+			hostOS:      "cos",
 			want:        []string{"eth0"},
+		},
+		{
+			name:        "File empty - returns default ens4 on ubuntu",
+			fileContent: "",
+			hostOS:      "ubuntu",
+			want:        []string{"ens4"},
 		},
 		{
 			name:        "Single NIC",
 			fileContent: "tcp0(eth0)",
+			hostOS:      "cos",
 			want:        []string{"eth0"},
 		},
 		{
 			name:        "Multi NIC",
 			fileContent: "tcp0(eth0,eth1)",
+			hostOS:      "cos",
 			want:        []string{"eth0", "eth1"},
 		},
 		{
 			name:         "Validation match",
 			fileContent:  "tcp0(eth0,eth1)",
 			expectedNics: "tcp0(eth0,eth1)",
+			hostOS:       "cos",
 			want:         []string{"eth0", "eth1"},
 		},
 		{
 			name:         "Validation mismatch - single NIC expected",
 			fileContent:  "tcp0(eth0,eth1)",
 			expectedNics: "tcp0(eth0)",
+			hostOS:       "cos",
 			want:         []string{"eth0", "eth1"},
 		},
 		{
 			name:         "Validation mismatch - multi NIC expected",
 			fileContent:  "tcp0(eth0)",
 			expectedNics: "tcp0(eth0,eth1)",
+			hostOS:       "cos",
 			want:         []string{"eth0"},
 		},
 	}
@@ -176,7 +211,7 @@ func TestGetLnetNetwork(t *testing.T) {
 				}
 			}
 
-			got, err := getLnetNetwork(tc.expectedNics, networkFile)
+			got, err := getLnetNetwork(tc.expectedNics, networkFile, tc.hostOS)
 			if err != nil {
 				t.Fatalf("getLnetNetwork() unexpected error: %v", err)
 			}


### PR DESCRIPTION
Added support for installing lustre kernel modules on Ubuntu nodes. Updated support on node.yaml aswell to support both cos and ubuntu images.

Note: MultiNic on Ubuntu was not functioning properly from the changes in this PR. Will further investigate and work seperately from this PR. The goal of this PR would build a skeleton and introduce Ubuntu kmod install.


### Local sandbox testing (Port 988 and w/o MultiNic):
Daemonset/CSI Node pods are running:
<img width="2588" height="544" alt="image" src="https://github.com/user-attachments/assets/5e500bdf-3554-4f17-ab93-81bad63e6b5c" />

With 6988 legacy port:
<img width="2758" height="1188" alt="image" src="https://github.com/user-attachments/assets/dd66d722-34b1-4f24-89d2-a666834dc071" />

Succesful logs (tested 988/6988) :
<img width="3370" height="1722" alt="image" src="https://github.com/user-attachments/assets/bc3b972d-e64c-48f8-9445-7ed08e3ad792" />

volume mount testing:
<img width="2576" height="550" alt="image" src="https://github.com/user-attachments/assets/06c455c4-597d-4b0c-828f-7082b8227b3b" />

if scope is not defined at cluster and nodepool creation, user will receive this error:
<img width="1657" height="677" alt="image" src="https://github.com/user-attachments/assets/fb960c8e-8735-4199-af33-0fa2cdae2417" />






