### PR TITLE
Implement IAM upcall IPC routing logic

### DIFF
--- a/cmd/lustre-host-proxy/main.go
+++ b/cmd/lustre-host-proxy/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -28,6 +29,7 @@ const (
 	defaultSocketPath = "/var/lib/kubelet/plugins/lustre.csi.storage.gke.io/ipc.sock"
 	socketEnvVar      = "LUSTRE_IPC_SOCKET"
 	timeoutDuration   = 60 * time.Second
+	iamUpcallBinary   = "l_gssiam_upcall"
 )
 
 type Request struct {
@@ -43,9 +45,18 @@ type Response struct {
 }
 
 func main() {
-	if len(os.Args) < 2 {
-		fmt.Fprintf(os.Stderr, "Usage: %s <command> [args...]\n", os.Args[0])
-		os.Exit(1)
+	invocationName := filepath.Base(os.Args[0])
+
+	var args []string
+	if invocationName == iamUpcallBinary {
+		// When invoked as the upcall symlink, we forward all arguments including the invocation name.
+		args = os.Args
+	} else {
+		if len(os.Args) < 2 {
+			fmt.Fprintf(os.Stderr, "Usage: %s <command> [args...]\n", os.Args[0])
+			os.Exit(1)
+		}
+		args = os.Args[1:]
 	}
 
 	socketPath := os.Getenv(socketEnvVar)
@@ -54,7 +65,7 @@ func main() {
 	}
 
 	req := Request{
-		Args: os.Args[1:],
+		Args: args,
 		Env:  os.Environ(),
 	}
 

--- a/pkg/upcall/server.go
+++ b/pkg/upcall/server.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -33,6 +34,9 @@ import (
 
 const (
 	containerSocketPath = "/csi/ipc.sock"
+	iamUpcallBinary     = "l_gssiam_upcall"
+	iamUpcallPath       = "/usr/sbin/l_gssiam_upcall"
+	lctlPath            = "/usr/sbin/lctl"
 )
 
 type Request struct {
@@ -120,6 +124,11 @@ func executeCommand(ctx context.Context, req Request) Response {
 	binaryPath := req.Args[0]
 	cmdArgs := req.Args[1:]
 
+	if filepath.Base(binaryPath) == iamUpcallBinary {
+		// Route generic upcall invocation name to the absolute container path.
+		binaryPath = iamUpcallPath
+	}
+
 	// Strict Security Whitelist Validation.
 	if err := validateCommand(binaryPath, cmdArgs); err != nil {
 		klog.Errorf("Security rejection: %v", err)
@@ -176,10 +185,13 @@ func executeCommand(ctx context.Context, req Request) Response {
 
 func validateCommand(binary string, args []string) error {
 	switch binary {
-	case "/usr/sbin/lctl":
+	case lctlPath:
 		if len(args) < 2 || args[0] != "set_param" {
 			return fmt.Errorf("unauthorized lctl subcommand or arguments: %v", args)
 		}
+		return nil
+	case iamUpcallPath:
+		// Allow the IAM upcall binary.
 		return nil
 	default:
 		return fmt.Errorf("unauthorized binary path execution request: %s", binary)

--- a/pkg/upcall/server_test.go
+++ b/pkg/upcall/server_test.go
@@ -40,6 +40,12 @@ func TestValidateCommand(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "Valid l_gssiam_upcall",
+			binary:  "/usr/sbin/l_gssiam_upcall",
+			args:    []string{"-o", "user"},
+			wantErr: false,
+		},
+		{
 			name:    "Invalid lctl subcommand",
 			binary:  "/usr/sbin/lctl",
 			args:    []string{"get_param", "osc.*.max_dirty_mb"},
@@ -134,5 +140,26 @@ func TestServerEndToEndMock(t *testing.T) {
 	// It should pass validation and fail on execution because /usr/sbin/lctl doesn't exist on the test runner host
 	if !strings.Contains(resp2.Error, "no such file or directory") {
 		t.Errorf("expected execution to fail due to missing binary, but expected validation to pass. Got resp: %+v", resp2)
+	}
+
+	// Test 3: IAM upcall routing with full path
+	clientConn3, err := net.Dial("unix", tmpSock)
+	if err != nil {
+		t.Fatalf("failed to dial test socket third time: %v", err)
+	}
+
+	req3 := Request{
+		Args: []string{"/etc/udev/l_gssiam_upcall", "arg1", "arg2"},
+		Env:  os.Environ(),
+	}
+	_ = json.NewEncoder(clientConn3).Encode(req3)
+
+	var resp3 Response
+	_ = json.NewDecoder(clientConn3).Decode(&resp3)
+	_ = clientConn3.Close()
+
+	// It should pass validation (routed to /usr/sbin/l_gssiam_upcall) and fail on execution
+	if !strings.Contains(resp3.Error, "/usr/sbin/l_gssiam_upcall") || !strings.Contains(resp3.Error, "no such file or directory") {
+		t.Errorf("expected routing to /usr/sbin/l_gssiam_upcall to pass validation but fail execution for full path. Got resp: %+v", resp3)
 	}
 }


### PR DESCRIPTION
- Host Proxy: Updated lustre-host-proxy to detect l_gssiam_upcall invocation and forward all arguments (including the invocation name) via UDS.
- IPC Server: Implemented automatic routing of l_gssiam_upcall to the absolute container path /usr/sbin/l_gssiam_upcall.
- Security: Updated the server's command whitelist to explicitly allow the IAM upcall binary.