### PR TITLE
Prow test ubuntu support for Lustre CSI

### DIFF
--- a/test/k8s-integration/cluster.go
+++ b/test/k8s-integration/cluster.go
@@ -182,9 +182,15 @@ func clusterUpGKE(project, gceZone, gceRegion, imageType string, numNodes, multi
 		}
 	}
 
-	if !useManagedDriver {
-		cmdParams = append(cmdParams, "--enable-kernel-module-signature-enforcement")
+	// For setting specific flags based on image type (cos or ubuntu).
+	imageSpecificFlags := []string{}
+	if !useManagedDriver && imageType == "cos_containerd" {
+		imageSpecificFlags = append(imageSpecificFlags, "--enable-kernel-module-signature-enforcement")
 	}
+	if imageType == "ubuntu_containerd" {
+		imageSpecificFlags = append(imageSpecificFlags, "--scopes=https://www.googleapis.com/auth/cloud-platform")
+	}
+	cmdParams = append(cmdParams, imageSpecificFlags...)
 
 	cmd = exec.Command("gcloud")
 	cmd.Args = append(cmd.Args, cmdParams...)
@@ -199,10 +205,10 @@ func clusterUpGKE(project, gceZone, gceRegion, imageType string, numNodes, multi
 			"--cluster=" + *gkeTestClusterName, locationArg, locationVal,
 			"--num-nodes=" + strconv.Itoa(multiNicNumNodes), "--additional-node-network",
 			"network=" + *clusterNetwork + ",subnetwork=" + multinicSubnetName,
+			"--image-type", imageType,
 		}
-		if !useManagedDriver {
-			nodePoolCmd = append(nodePoolCmd, "--enable-kernel-module-signature-enforcement")
-		}
+		nodePoolCmd = append(nodePoolCmd, imageSpecificFlags...)
+
 		cmd = exec.Command("gcloud")
 		cmd.Args = append(cmd.Args, nodePoolCmd...)
 		err = runCommand("Creating Multi-Nic Nodepool", cmd)

--- a/test/run-k8s-integration-local.sh
+++ b/test/run-k8s-integration-local.sh
@@ -27,4 +27,4 @@ multivolume_fs_test_focus="External.*Storage.*filesystem.*multiVolume"
 "${PKGDIR}"/bin/k8s-integration-test --run-in-prow=false --pkg-dir="${PKGDIR}" \
 --bringup-cluster=true --test-focus="${all_external_tests_focus}" --do-network-setup=true \
 --do-driver-build=true --gce-zone="us-central1-c" --use-gke-driver=false \
---num-nodes="${NUM_NODES:-1}" --multi-nic-num-nodes="${MULTI_NIC_NUM_NODES:-1}" --parallel=1 -test-version=1.32 --gke-cluster-version=1.32
+--num-nodes="${NUM_NODES:-1}" --multi-nic-num-nodes="${MULTI_NIC_NUM_NODES:-1}" --parallel=1 -test-version=1.32 --gke-cluster-version=1.32 --image-type="${IMAGE_TYPE:-cos_containerd}"

--- a/test/run-k8s-integration.sh
+++ b/test/run-k8s-integration.sh
@@ -32,6 +32,7 @@ readonly parallel_run=${PARALLEL:-}
 readonly test_focus=${TEST_FOCUS:-}
 readonly test_version=${TEST_VERSION:-1.32}
 readonly enable_legacy_lustre_port=${ENABLE_LEGACY_LUSTRE_PORT:-true}
+readonly image_type="${IMAGE_TYPE:-cos_containerd}"
 
 make -C "${PKGDIR}" test-k8s-integration
 
@@ -48,7 +49,7 @@ base_cmd="${PKGDIR}/bin/k8s-integration-test \
             --do-driver-build=${do_driver_build} --boskos-resource-type=${boskos_resource_type} \
             --test-version=${test_version} --num-nodes=1 --multi-nic-num-nodes=1 --pkg-dir=${PKGDIR} \
             --use-gke-driver=${use_gke_driver} --gke-cluster-version=${gke_cluster_version} \
-            --enable-legacy-lustre-port=${enable_legacy_lustre_port}"
+            --enable-legacy-lustre-port=${enable_legacy_lustre_port} --image-type=${image_type}"
 
 if [ -n "$gke_node_version" ]; then
   base_cmd="${base_cmd} --gke-node-version=${gke_node_version}"


### PR DESCRIPTION
Prow test support for running Ubuntu image type.

Test with `ubuntu_containerd` image type:
<img width="3456" height="604" alt="image" src="https://github.com/user-attachments/assets/6865a48a-5d4a-4d22-a41f-bf01253b0bfb" />

<img width="3456" height="684" alt="image" src="https://github.com/user-attachments/assets/db354d41-b0f3-47ee-8cbc-31a95822cbbb" />
