### PR TITLE
Refactor capturing primary NIC by comparing MAC address

### DIFF
--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -82,10 +82,17 @@ func main() {
 		config.MetadataService = meta
 		config.Mounter = mount.New("")
 
+		netlinker := network.NewNetlink()
 		nodeClient := network.NewK8sClient()
 		hostOS, err := kmod.HostOSFromNodeLabel(ctx, *nodeID, nodeClient)
 		if err != nil {
 			klog.Fatalf("Failed to read OS Host Info: %v", err)
+		}
+
+		networkIntf := network.Manager(netlinker, nodeClient, meta)
+		defaultNic, err := networkIntf.GetPrimaryNIC()
+		if err != nil {
+			klog.Fatalf("Failed to identify primary NIC: %v", err)
 		}
 
 		// Set up host proxy and start the upcall IPC server only on COS nodes.
@@ -105,16 +112,11 @@ func main() {
 		klog.Info("Retrieving the network interface specified in LNET parameters.")
 		// Pass an empty string as expected network because the kmod-installer initContainer is responsible
 		// for configuring multi-NIC and loading the module. CSI driver will just read the actual config.
-		nics, err := kmod.GetLnetNetwork("", hostOS)
+		nics, err := kmod.GetLnetNetwork("", defaultNic)
 		if err != nil {
 			klog.Fatalf("Failed to get LNET network parameters: %v", err)
 		}
-		// These NICs will require additional setup for multi nic feature.
-		defaultNic := "eth0"
-		if hostOS == "ubuntu" {
-			// This is an assumption we've made that Ubuntu nodes will always use ens4 as default NIC.
-			defaultNic = "ens4"
-		}
+
 		additionalNics := []string{}
 		for _, nic := range nics {
 			if nic != defaultNic {

--- a/cmd/kmod_installer/main.go
+++ b/cmd/kmod_installer/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"strings"
 
 	gcemetadata "cloud.google.com/go/compute/metadata"
@@ -80,6 +79,11 @@ func main() {
 		klog.Fatal("No standard NICs (gve, idpf, or virtio_net) found")
 	}
 
+	primaryNic, err := networkIntf.GetPrimaryNIC()
+	if err != nil {
+		klog.Fatalf("Failed to identify primary NIC: %v", err)
+	}
+
 	effectiveDisableMultiNIC, err := networkIntf.CheckDisableMultiNIC(ctx, *nodeID, nics, *disableMultiNIC)
 	if err != nil {
 		klog.Fatalf("Failed to check multi-NIC status: %v", err)
@@ -98,15 +102,8 @@ func main() {
 
 	if isInstalled {
 		// Check if the current configuration matches the expectation.
-		expectedNetwork := kmod.DefaultCosLnetNetwork
-		if hostOS == "ubuntu" {
-			expectedNetwork = kmod.DefaultUbuntuLnetNetwork
-		}
-
-		if !effectiveDisableMultiNIC {
-			expectedNetwork = fmt.Sprintf("tcp0(%s)", strings.Join(nics, ","))
-		}
-		if _, err = kmod.GetLnetNetwork(expectedNetwork, hostOS); err != nil {
+		expectedNetwork := kmod.BuildLnetNetworkString(nics, primaryNic, effectiveDisableMultiNIC)
+		if _, err = kmod.GetLnetNetwork(expectedNetwork, primaryNic); err != nil {
 			klog.Fatalf("Failed to get LNET network parameters: %v", err)
 		}
 
@@ -118,7 +115,7 @@ func main() {
 
 	switch hostOS {
 	case "cos":
-		err = kmod.InstallLustreKmodOnCos(ctx, *enableLegacyLustrePort, customModuleArgs, nics, effectiveDisableMultiNIC)
+		err = kmod.InstallLustreKmodOnCos(ctx, *enableLegacyLustrePort, customModuleArgs, nics, effectiveDisableMultiNIC, primaryNic)
 		if err != nil {
 			klog.Fatalf("Failed to install lustre kernel modules on COS: %v", err)
 		}
@@ -138,7 +135,7 @@ func main() {
 				klog.Fatalf("The https://www.googleapis.com/auth/cloud-platform scope is missing. This is required for installing Lustre packages from Artifact Registry")
 			}
 		}
-		err = kmod.InstallLustreKmodOnUbuntu(ctx, *enableLegacyLustrePort, customModuleArgs, nics, effectiveDisableMultiNIC)
+		err = kmod.InstallLustreKmodOnUbuntu(ctx, *enableLegacyLustrePort, customModuleArgs, nics, effectiveDisableMultiNIC, primaryNic)
 		if err != nil {
 			klog.Fatalf("Failed to install lustre kernel modules on Ubuntu: %v", err)
 		}

--- a/pkg/kmod_installer/kmod_installer.go
+++ b/pkg/kmod_installer/kmod_installer.go
@@ -30,12 +30,10 @@ import (
 )
 
 const (
-	legacyLNetPort           = 6988
-	defaultLNetPort          = 988
-	cmdTimeout               = 15 * time.Minute
-	DefaultCosLnetNetwork    = "tcp0(eth0)"
-	DefaultUbuntuLnetNetwork = "tcp0(ens4)"
-	osNodeLabel              = "cloud.google.com/gke-os-distribution"
+	legacyLNetPort  = 6988
+	defaultLNetPort = 988
+	cmdTimeout      = 15 * time.Minute
+	osNodeLabel     = "cloud.google.com/gke-os-distribution"
 )
 
 var (
@@ -96,21 +94,18 @@ func isLustreKmodInstalled(enableLegacyLustrePort bool, acceptPortFile, lustreMo
 // GetLnetNetwork retrieves the currently configured LNet network interfaces.
 // It reads the "networks" parameter from the LNet module parameters.
 // If expectedNics is provided, it validates the current config matches expectation and warns on mismatch.
-// If the file is missing but modules are installed, it returns a default "eth0".
-func GetLnetNetwork(expectedNics, hostOS string) ([]string, error) {
-	return getLnetNetwork(expectedNics, lnetNetworkParameterFile, hostOS)
+// If the file is missing but modules are installed, it returns a default network based on defaultNic.
+func GetLnetNetwork(expectedNics, defaultNic string) ([]string, error) {
+	return getLnetNetwork(expectedNics, lnetNetworkParameterFile, defaultNic)
 }
 
-func getLnetNetwork(expectedNics, networkFile, hostOS string) ([]string, error) {
-	networkStr, err := readLnetConfig(networkFile, hostOS)
+func getLnetNetwork(expectedNics, networkFile, defaultNic string) ([]string, error) {
+	networkStr, err := readLnetConfig(networkFile, defaultNic)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// If the LNET parameter file is missing but modules are supposedly installed,
-			// falling back to a (tcp0(eth0)) / (tcp0(ens4)) as the default.
-			networkStr = DefaultCosLnetNetwork
-			if hostOS == "ubuntu" {
-				networkStr = DefaultUbuntuLnetNetwork
-			}
+			// falling back to a default network using defaultNic.
+			networkStr = fmt.Sprintf("tcp0(%s)", defaultNic)
 		} else {
 			return nil, err
 		}
@@ -123,7 +118,7 @@ func getLnetNetwork(expectedNics, networkFile, hostOS string) ([]string, error) 
 	return parseLnetNetwork(networkStr), nil
 }
 
-func readLnetConfig(path, hostOS string) (string, error) {
+func readLnetConfig(path, defaultNic string) (string, error) {
 	file, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
@@ -133,11 +128,8 @@ func readLnetConfig(path, hostOS string) (string, error) {
 		klog.V(4).Infof("LNET network parameter file %v is empty.", path)
 		// An empty lnetNetworkParameterFile implies either the kernel modules are not installed yet,
 		// or they are installed, but just without any parameters.
-		// If that file is empty, but kernel modules are already installed, eth0 should be used.
-		if hostOS == "ubuntu" {
-			return DefaultUbuntuLnetNetwork, nil
-		}
-		return DefaultCosLnetNetwork, nil
+		// If that file is empty, but kernel modules are already installed, defaultNic should be used.
+		return fmt.Sprintf("tcp0(%s)", defaultNic), nil
 	}
 
 	return currNetworkNics, nil
@@ -145,12 +137,9 @@ func readLnetConfig(path, hostOS string) (string, error) {
 
 // InstallLustreKmodOnCos installs the Lustre kernel modules on the node using cos-dkms on COS nodes.
 // It proceeds with the installation using the provided NICs.
-func InstallLustreKmodOnCos(ctx context.Context, enableLegacyPort bool, customModuleArgs []string, nics []string, disableMultiNIC bool) error {
+func InstallLustreKmodOnCos(ctx context.Context, enableLegacyPort bool, customModuleArgs []string, nics []string, disableMultiNIC bool, primaryNic string) error {
 	lnetPort := lnetPort(enableLegacyPort)
-	expectedNetwork := DefaultCosLnetNetwork
-	if !disableMultiNIC {
-		expectedNetwork = fmt.Sprintf("tcp0(%s)", strings.Join(nics, ","))
-	}
+	expectedNetwork := BuildLnetNetworkString(nics, primaryNic, disableMultiNIC)
 
 	cmdCtx, cancel := context.WithTimeout(ctx, cmdTimeout)
 	defer cancel()
@@ -212,12 +201,9 @@ func InstallLustreKmodOnCos(ctx context.Context, enableLegacyPort bool, customMo
 }
 
 // InstallLustreKmodOnUbuntu installs the Lustre kernel modules on Ubuntu nodes.
-func InstallLustreKmodOnUbuntu(ctx context.Context, enableLegacyPort bool, customModuleArgs []string, nics []string, disableMultiNIC bool) error {
+func InstallLustreKmodOnUbuntu(ctx context.Context, enableLegacyPort bool, customModuleArgs []string, nics []string, disableMultiNIC bool, primaryNic string) error {
 	lnetPort := lnetPort(enableLegacyPort)
-	expectedNetwork := DefaultUbuntuLnetNetwork
-	if len(nics) > 0 && !disableMultiNIC {
-		expectedNetwork = fmt.Sprintf("tcp0(%s)", strings.Join(nics, ","))
-	}
+	expectedNetwork := BuildLnetNetworkString(nics, primaryNic, disableMultiNIC)
 
 	cmdCtx, cancel := context.WithTimeout(ctx, cmdTimeout)
 	defer cancel()
@@ -352,4 +338,18 @@ func HostOSFromNodeLabel(ctx context.Context, nodeID string, nc network.NodeClie
 		return "unknown", nil
 	}
 	return val, nil
+}
+
+// BuildLnetNetworkString constructs the LNet network configuration string.
+func BuildLnetNetworkString(nics []string, primaryNic string, disableMultiNIC bool) string {
+	if disableMultiNIC {
+		return fmt.Sprintf("tcp0(%s)", primaryNic)
+	}
+	orderedNics := []string{primaryNic}
+	for _, nic := range nics {
+		if nic != primaryNic {
+			orderedNics = append(orderedNics, nic)
+		}
+	}
+	return fmt.Sprintf("tcp0(%s)", strings.Join(orderedNics, ","))
 }

--- a/pkg/kmod_installer/kmod_installer_test.go
+++ b/pkg/kmod_installer/kmod_installer_test.go
@@ -135,7 +135,7 @@ func TestGetLnetNetwork(t *testing.T) {
 		fileContent  string
 		fileMissing  bool
 		expectedNics string
-		hostOS       string
+		defaultNic   string
 		want         []string
 		// We don't check for specific log output here, but we verify the return values
 		// and that it doesn't crash on warnings.
@@ -143,58 +143,58 @@ func TestGetLnetNetwork(t *testing.T) {
 		{
 			name:        "File missing - returns default eth0 on cos",
 			fileMissing: true,
-			hostOS:      "cos",
+			defaultNic:  "eth0",
 			want:        []string{"eth0"},
 		},
 		{
 			name:        "File missing - returns default ens4 on ubuntu",
 			fileMissing: true,
-			hostOS:      "ubuntu",
+			defaultNic:  "ens4",
 			want:        []string{"ens4"},
 		},
 		{
 			name:        "File empty - returns default eth0 on cos",
 			fileContent: "",
-			hostOS:      "cos",
+			defaultNic:  "eth0",
 			want:        []string{"eth0"},
 		},
 		{
 			name:        "File empty - returns default ens4 on ubuntu",
 			fileContent: "",
-			hostOS:      "ubuntu",
+			defaultNic:  "ens4",
 			want:        []string{"ens4"},
 		},
 		{
 			name:        "Single NIC",
 			fileContent: "tcp0(eth0)",
-			hostOS:      "cos",
+			defaultNic:  "eth0",
 			want:        []string{"eth0"},
 		},
 		{
 			name:        "Multi NIC",
 			fileContent: "tcp0(eth0,eth1)",
-			hostOS:      "cos",
+			defaultNic:  "eth0",
 			want:        []string{"eth0", "eth1"},
 		},
 		{
 			name:         "Validation match",
 			fileContent:  "tcp0(eth0,eth1)",
 			expectedNics: "tcp0(eth0,eth1)",
-			hostOS:       "cos",
+			defaultNic:   "eth0",
 			want:         []string{"eth0", "eth1"},
 		},
 		{
 			name:         "Validation mismatch - single NIC expected",
 			fileContent:  "tcp0(eth0,eth1)",
 			expectedNics: "tcp0(eth0)",
-			hostOS:       "cos",
+			defaultNic:   "eth0",
 			want:         []string{"eth0", "eth1"},
 		},
 		{
 			name:         "Validation mismatch - multi NIC expected",
 			fileContent:  "tcp0(eth0)",
 			expectedNics: "tcp0(eth0,eth1)",
-			hostOS:       "cos",
+			defaultNic:   "eth0",
 			want:         []string{"eth0"},
 		},
 	}
@@ -211,7 +211,7 @@ func TestGetLnetNetwork(t *testing.T) {
 				}
 			}
 
-			got, err := getLnetNetwork(tc.expectedNics, networkFile, tc.hostOS)
+			got, err := getLnetNetwork(tc.expectedNics, networkFile, tc.defaultNic)
 			if err != nil {
 				t.Fatalf("getLnetNetwork() unexpected error: %v", err)
 			}
@@ -285,6 +285,71 @@ func TestHostOSFromNodeLabel(t *testing.T) {
 			// Node label value check
 			if got != tc.wantOS {
 				t.Errorf("HostOSFromNodeLabel() got = %v, want %v", got, tc.wantOS)
+			}
+		})
+	}
+}
+
+func TestBuildLnetNetworkString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		nics            []string
+		primaryNic      string
+		disableMultiNIC bool
+		want            string
+	}{
+		{
+			name:            "single NIC, multiNIC disabled",
+			nics:            []string{"eth0"},
+			primaryNic:      "eth0",
+			disableMultiNIC: true,
+			want:            "tcp0(eth0)",
+		},
+		{
+			name:            "multiple NICs, multiNIC disabled",
+			nics:            []string{"eth0", "eth1"},
+			primaryNic:      "eth0",
+			disableMultiNIC: true,
+			want:            "tcp0(eth0)",
+		},
+		{
+			name:            "multiple NICs, multiNIC enabled, primary is first",
+			nics:            []string{"eth0", "eth1"},
+			primaryNic:      "eth0",
+			disableMultiNIC: false,
+			want:            "tcp0(eth0,eth1)",
+		},
+		{
+			name:            "multiple NICs, multiNIC enabled, primary is not first",
+			nics:            []string{"eth1", "eth0"},
+			primaryNic:      "eth0",
+			disableMultiNIC: false,
+			want:            "tcp0(eth0,eth1)",
+		},
+		{
+			name:            "multiple NICs, multiNIC enabled, extra NICs",
+			nics:            []string{"eth1", "eth0", "eth2"},
+			primaryNic:      "eth0",
+			disableMultiNIC: false,
+			want:            "tcp0(eth0,eth1,eth2)",
+		},
+		{
+			name:            "empty nics, multiNIC enabled",
+			nics:            []string{},
+			primaryNic:      "eth0",
+			disableMultiNIC: false,
+			want:            "tcp0(eth0)",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := BuildLnetNetworkString(tc.nics, tc.primaryNic, tc.disableMultiNIC)
+			if got != tc.want {
+				t.Errorf("BuildLnetNetworkString() got = %q, want %q", got, tc.want)
 			}
 		})
 	}

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -227,6 +227,45 @@ func (rm *RouteManager) validateNICs(nics []string) ([]string, error) {
 	return validNICs, nil
 }
 
+// GetPrimaryNIC identifies the primary network interface name (e.g. eth0, ens4) by matching
+// the kernel network interface MAC address with GCE metadata interface 0 MAC address.
+func (rm *RouteManager) GetPrimaryNIC() (string, error) {
+	if rm.mc == nil {
+		return "", errors.New("metadata client is nil, cannot identify primary NIC")
+	}
+
+	metaNICs, err := rm.mc.GetNetworkInterfaces()
+	if err != nil {
+		return "", fmt.Errorf("failed to get network interfaces from metadata: %w", err)
+	}
+
+	if len(metaNICs) == 0 {
+		return "", errors.New("no network interfaces found in instance metadata")
+	}
+
+	primaryMAC := strings.ToLower(metaNICs[0].Mac)
+
+	nics, err := rm.nl.GetStandardNICs()
+	if err != nil {
+		return "", fmt.Errorf("failed to get standard NICs: %w", err)
+	}
+
+	for _, nic := range nics {
+		link, err := rm.nl.LinkByName(nic)
+		if err != nil {
+			klog.Warningf("Failed to get link for %s: %v", nic, err)
+			continue
+		}
+		mac := strings.ToLower(link.Attrs().HardwareAddr.String())
+		if mac == primaryMAC {
+			klog.V(4).Infof("Identified primary NIC %s with MAC %s", nic, mac)
+			return nic, nil
+		}
+	}
+
+	return "", fmt.Errorf("no standard NIC found matching primary metadata MAC %s", primaryMAC)
+}
+
 func (rm *RouteManager) configureRoutesForNIC(nicName string, nicIPAddr net.IP, instanceIPAddr string, tableID int) error {
 	// Get the network interface handle
 	link, err := rm.nl.LinkByName(nicName)

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -719,3 +719,102 @@ func TestCheckDisableMultiNIC(t *testing.T) {
 		})
 	}
 }
+
+func TestGetPrimaryNIC(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		fakeGvnicNames []string
+		fakeErr        error
+		fakeNics       []metadata.NetworkInterface
+		fakeMetaErr    error
+		wantNic        string
+		wantErr        bool
+	}{
+		{
+			name:           "Successfully match primary NIC by MAC",
+			fakeGvnicNames: []string{"eth0", "eth1"},
+			fakeNics: []metadata.NetworkInterface{
+				{Network: "default", Mac: "00:00:00:00:00:01"},
+				{Network: "default", Mac: "00:00:00:00:00:02"},
+			},
+			wantNic: "eth0",
+			wantErr: false,
+		},
+		{
+			name:           "Successfully match primary NIC when enumeration order differs",
+			fakeGvnicNames: []string{"ens5", "ens4"},
+			fakeNics: []metadata.NetworkInterface{
+				{Network: "default", Mac: "00:00:00:00:00:02"}, // Primary metadata interface MAC ends in 02
+			},
+			wantNic: "ens4",
+			wantErr: false,
+		},
+		{
+			name:    "Metadata client is nil",
+			wantErr: true,
+		},
+		{
+			name:        "Metadata error",
+			fakeMetaErr: errors.New("metadata server error"),
+			wantErr:     true,
+		},
+		{
+			name:     "No metadata NICs returned",
+			fakeNics: []metadata.NetworkInterface{},
+			wantErr:  true,
+		},
+		{
+			name:           "Netlink error",
+			fakeGvnicNames: []string{"eth0", "eth1"},
+			fakeNics: []metadata.NetworkInterface{
+				{Network: "default", Mac: "00:00:00:00:00:01"},
+			},
+			fakeErr: errors.New("netlink get standard nics error"),
+			wantErr: true,
+		},
+		{
+			name:           "No matching kernel interface MAC found",
+			fakeGvnicNames: []string{"eth0"},
+			fakeNics: []metadata.NetworkInterface{
+				{Network: "default", Mac: "99:99:99:99:99:99"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var metaClient MetadataClient
+			if test.fakeNics != nil {
+				metaClient = &fakeMetadataClient{
+					getNicsResponse: test.fakeNics,
+					getNicsErr:      test.fakeMetaErr,
+				}
+			}
+
+			fakeNL := &fakeNetlink{
+				getStandardNICsResponse: test.fakeGvnicNames,
+				getStandardNICsErr:      test.fakeErr,
+				linkByNameMap: map[string]netlink.Link{
+					"eth0": fakeLink{attrs: &netlink.LinkAttrs{Name: "eth0", HardwareAddr: net.HardwareAddr{0, 0, 0, 0, 0, 1}}},
+					"eth1": fakeLink{attrs: &netlink.LinkAttrs{Name: "eth1", HardwareAddr: net.HardwareAddr{0, 0, 0, 0, 0, 2}}},
+					"ens4": fakeLink{attrs: &netlink.LinkAttrs{Name: "ens4", HardwareAddr: net.HardwareAddr{0, 0, 0, 0, 0, 2}}},
+					"ens5": fakeLink{attrs: &netlink.LinkAttrs{Name: "ens5", HardwareAddr: net.HardwareAddr{0, 0, 0, 0, 0, 3}}},
+				},
+			}
+
+			networkManager := Manager(fakeNL, nil, metaClient)
+			gotNic, err := networkManager.GetPrimaryNIC()
+			if (err != nil) != test.wantErr {
+				t.Errorf("GetPrimaryNIC() error = %v, wantErr %v", err, test.wantErr)
+			}
+			if !test.wantErr && gotNic != test.wantNic {
+				t.Errorf("GetPrimaryNIC() = %v, want %v", gotNic, test.wantNic)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Problem
Currently, the Lustre CSI driver and kernel module installer rely on hardcoded OS-specific interface names to identify the primary NIC:
cos -> eth0
ubuntu -> ens4

This hardcoded assumption is fragile, particularly on Ubuntu and newer GCE machine families. If GCE introduces a new machine type, alters the virtual PCI bridge layout, or if attaching secondary NICs/local SSDs shifts the kernel enumeration order during boot, interface names can unpredictably shift (e.g.,`ens5`, `enp0s5`).

### Solution
To ensure robust, deterministic NIC identification across all OS distributions and hardware configurations, this PR replaces static interface name constants with dynamic hardware MAC address matching.

The driver now queries the GCE Metadata Server for the primary network interface (`nic0`), extracts its hardware MAC address (`metaNICs[0].Mac`), and correlates it against the host's kernel netlink devices to reliably identify the exact primary interface name on the system.

### Testing:

Local testing showed that it was able to detect Primary Nic from mac address:
<img width="2700" height="904" alt="image" src="https://github.com/user-attachments/assets/4a2a21a9-9639-4f76-9fcf-1e0f31624748" />



