### PR TITLE
Skip NodeStageVolume for IAM-enabled volumes

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/lustre-csi-driver/pkg/network"
 	"github.com/GoogleCloudPlatform/lustre-csi-driver/pkg/util"
@@ -84,9 +85,11 @@ func (s *nodeServer) NodeStageVolume(_ context.Context, req *csi.NodeStageVolume
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
+
 	ip := vc[keyInstanceIP]
 	fsname := vc[keyFilesystem]
 	mountPoint := vc[normalize(keyMountPoint)]
+	iamAccessControlEnabled := vc[normalize(keyIAMAccessControlEnabled)]
 
 	if len(mountPoint) != 0 {
 		var err error
@@ -102,6 +105,11 @@ func (s *nodeServer) NodeStageVolume(_ context.Context, req *csi.NodeStageVolume
 
 	if len(fsname) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Lustre filesystem name is not provided")
+	}
+
+	if strings.ToLower(iamAccessControlEnabled) == "true" {
+		klog.V(4).Infof("NodeStageVolume skipping for IAM-enabled volume %s", volumeID)
+		return &csi.NodeStageVolumeResponse{}, nil
 	}
 
 	source := fmt.Sprintf("%s@tcp:/%s", ip, fsname)

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -130,6 +130,21 @@ func TestNodeStageVolme(t *testing.T) {
 			expectErr: true,
 		},
 		{
+			name: "IAM enabled request skipped",
+			req: &csi.NodeStageVolumeRequest{
+				VolumeId:          testVolumeID,
+				StagingTargetPath: stagingTargetPath,
+				VolumeCapability:  testVolumeCapability,
+				VolumeContext: map[string]string{
+					keyInstanceIP:              "127.0.0.2",
+					keyFilesystem:              testFilesystem,
+					keyIAMAccessControlEnabled: "true",
+				},
+			},
+			expectErr:     false,
+			expectedMount: nil,
+		},
+		{
 			name:   "same fsname already mounted",
 			mounts: []mount.MountPoint{{Device: testDevice, Path: stagingTargetPath}},
 			req: &csi.NodeStageVolumeRequest{


### PR DESCRIPTION
Updated `node.go` to skip NodeStageVolume for IAM enabled volumes, as IAM mounts require pod identity which is available only in NodePublishVolume.

For IAM-enabled volumes, the Multi-NIC configuration and parameter validation will move from NodeStageVolume to NodePublishVolume. This will allow us to keep the code and workflow clean for IAM enabled volumes.