### PR TITLE
[main to Release-0.6] Reintroduce lustre-kmod-installer as a Golang-based initContainer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ LDFLAGS ?= -s -w -X main.version=${STAGINGVERSION} -extldflags '-static'
 PROJECT ?= $(shell gcloud config list --format 'value(core.project)')
 REGISTRY ?= gcr.io/$(PROJECT)
 DRIVER_IMAGE = $(REGISTRY)/$(DRIVER_BINARY)
+KMOD_INSTALLER_IMAGE = $(REGISTRY)/lustre-kmod-installer
 GSA_FILE ?= ${HOME}/lustre_csi_driver_sa.json
 GSA_NS=lustre-csi-driver
 LUSTRE_ENDPOINT ?= prod
@@ -42,7 +43,9 @@ all: driver proxy
 
 build-all-image-and-push-multi-arch: init-buildx download-lustre-client-utils build-image-linux-amd64 build-image-linux-arm64
 	docker manifest create --amend $(DRIVER_IMAGE):$(STAGINGVERSION) $(DRIVER_IMAGE):$(STAGINGVERSION)_linux_amd64 $(DRIVER_IMAGE):$(STAGINGVERSION)_linux_arm64
+	docker manifest create --amend $(KMOD_INSTALLER_IMAGE):$(STAGINGVERSION) $(KMOD_INSTALLER_IMAGE):$(STAGINGVERSION)_linux_amd64 $(KMOD_INSTALLER_IMAGE):$(STAGINGVERSION)_linux_arm64
 	docker manifest push -p $(DRIVER_IMAGE):$(STAGINGVERSION)
+	docker manifest push -p $(KMOD_INSTALLER_IMAGE):$(STAGINGVERSION)
 
 build-image-linux-amd64:
 	docker buildx build ${DOCKER_BUILDX_ARGS} \
@@ -50,11 +53,21 @@ build-image-linux-amd64:
 		--tag ${DRIVER_IMAGE}:${STAGINGVERSION}_linux_amd64 \
 		--platform linux/amd64 \
 		--build-arg TARGETPLATFORM=linux/amd64 .
+	docker buildx build ${DOCKER_BUILDX_ARGS} \
+		--file ./cmd/kmod_installer/Dockerfile \
+		--tag ${KMOD_INSTALLER_IMAGE}:${STAGINGVERSION}_linux_amd64 \
+		--platform linux/amd64 \
+		--build-arg TARGETPLATFORM=linux/amd64 .
 
 build-image-linux-arm64:
 	docker buildx build ${DOCKER_BUILDX_ARGS} \
 		--file ./cmd/csi_driver/Dockerfile \
 		--tag ${DRIVER_IMAGE}:${STAGINGVERSION}_linux_arm64 \
+		--platform linux/arm64 \
+		--build-arg TARGETPLATFORM=linux/arm64 .
+	docker buildx build ${DOCKER_BUILDX_ARGS} \
+		--file ./cmd/kmod_installer/Dockerfile \
+		--tag ${KMOD_INSTALLER_IMAGE}:${STAGINGVERSION}_linux_arm64 \
 		--platform linux/arm64 \
 		--build-arg TARGETPLATFORM=linux/arm64 .
 
@@ -65,6 +78,10 @@ driver:
 proxy:
 	mkdir -p ${BINDIR}
 	CGO_ENABLED=0 GOOS=linux go build -mod vendor -ldflags "${LDFLAGS}" -o ${BINDIR}/lustre-host-proxy cmd/lustre-host-proxy/main.go
+
+kmod_installer:
+	mkdir -p ${BINDIR}
+	CGO_ENABLED=0 GOOS=linux go build -mod vendor -ldflags "${LDFLAGS}" -o ${BINDIR}/lustre-kmod-installer cmd/kmod_installer/main.go
 
 download-lustre-client-utils:
 	rm -rf ${BINDIR}/lustre/linux/*
@@ -97,8 +114,10 @@ generate-spec-yaml:
 	./deploy/install-kustomize.sh
 	if [ "${OVERLAY}" != "gke-release" ]; then \
 		cd ./deploy/overlays/${OVERLAY}; ../../../${BINDIR}/kustomize edit set image gke.gcr.io/lustre-csi-driver=${DRIVER_IMAGE}:${STAGINGVERSION}; \
+		cd ./deploy/overlays/${OVERLAY}; ../../../${BINDIR}/kustomize edit set image gke.gcr.io/lustre-kmod-installer=${KMOD_INSTALLER_IMAGE}:${STAGINGVERSION}; \
 		cd ./deploy/overlays/${OVERLAY}; ../../../${BINDIR}/kustomize edit add configmap lustre-config --behavior=merge --disableNameSuffixHash --from-literal=endpoint=${LUSTRE_ENDPOINT}; \
 	fi
+	# TODO: Replace the old disable-loadpin and install-lustre-mods initContainers below with lustre-kmod-installer once GKE release specs are updated to use it.
 	if [ "${DRIVER_ONLY}" = "true" ] && [ "${OVERLAY}" = "gke-release" ]; then \
 		echo "apiVersion: apps/v1" > ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
 		echo "kind: DaemonSet" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \

--- a/cmd/csi_driver/Dockerfile
+++ b/cmd/csi_driver/Dockerfile
@@ -30,7 +30,6 @@ RUN clean-install bash
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt \
-    kmod \
     dpkg \
     libyaml-0-2 \
     libnl-3-200 \
@@ -47,7 +46,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=gcr.io/cos-cloud/cos-dkms:v0.3.12 /usr/bin/cos-dkms /usr/bin/cos-dkms
 
 COPY /bin/lustre/$TARGETPLATFORM/lustre-client.deb /lustre/lustre-client.deb
 

--- a/cmd/csi_driver/main.go
+++ b/cmd/csi_driver/main.go
@@ -19,8 +19,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
-	"strings"
 
 	"github.com/GoogleCloudPlatform/lustre-csi-driver/pkg/cloud_provider/lustre"
 	"github.com/GoogleCloudPlatform/lustre-csi-driver/pkg/cloud_provider/metadata"
@@ -44,33 +42,15 @@ var (
 	lustreAPIEndpoint       = flag.String("lustre-endpoint", "", "Lustre API service endpoint, supported values are autopush, staging and prod.")
 	cloudConfigFilePath     = flag.String("cloud-config", "", "Path to GCE cloud provider config")
 	enableLegacyLustrePort  = flag.Bool("enable-legacy-lustre-port", false, "If set to true, the CSI driver controller will provision Lustre instance with the gkeSupportEnabled flag")
-	disableMultiNIC         = flag.Bool("disable-multi-nic", false, "If set to true, multi-NIC support is disabled and the driver will only use the default NIC (eth0).")
-	disableKmodInstall      = flag.Bool("disable-kmod-install", false, "If true, Lustre CSI driver will not install kmod and user will need to manage Lustre kmod independently.")
 	enableLabelController   = flag.Bool("enable-label-controller", true, "If true, the label controller will be started.")
 	leaderElectionNamespace = flag.String("leader-election-namespace", "", "Namespace where the leader election resource will be created. Required for out-of-cluster deployments.")
-
-	// customModuleArgs contains custom module-args arguments for cos-dkms installation provided by user.
-	customModuleArgs stringSlice
 
 	// These are set at compile time.
 	version = "unknown"
 )
 
-type stringSlice []string
-
-func (s *stringSlice) String() string {
-	return strings.Join(*s, ", ")
-}
-
-func (s *stringSlice) Set(value string) error {
-	*s = append(*s, value)
-
-	return nil
-}
-
 func main() {
 	klog.InitFlags(nil)
-	flag.Var(&customModuleArgs, "custom-module-args", "Custom module-args for cos-dkms install command. (Can be specified multiple times).")
 	flag.Parse()
 	mm := metrics.NewMetricsManager()
 	if *httpEndpoint != "" {
@@ -100,69 +80,12 @@ func main() {
 		}
 		klog.Infof("Metadata service setup: %+v", meta)
 		config.MetadataService = meta
-
-		netlinker := network.NewNetlink()
-		nodeClient := network.NewK8sClient()
-		networkIntf := network.Manager(netlinker, nodeClient, meta)
-
 		config.Mounter = mount.New("")
-		var (
-			nics                     []string
-			effectiveDisableMultiNIC bool
-		)
 
-		// We need to get standard NICs to check if the current LNET configuration (if installed) matches expectation
-		// or to install if not installed.
-		nics, err = networkIntf.GetStandardNICs()
-		if err != nil {
-			klog.Fatalf("Failed to get nic names: %v", err)
-		}
-		if len(nics) == 0 {
-			klog.Fatal("No standard NICs (gve, idpf, or virtio_net) found")
-		}
-
-		effectiveDisableMultiNIC, err = networkIntf.CheckDisableMultiNIC(ctx, *nodeID, nics, *disableMultiNIC)
-		if err != nil {
-			klog.Fatal(err)
-		}
-
+		nodeClient := network.NewK8sClient()
 		hostOS, err := kmod.HostOSFromNodeLabel(ctx, *nodeID, nodeClient)
 		if err != nil {
 			klog.Fatalf("Failed to read OS Host Info: %v", err)
-		}
-
-		isInstalled, err := kmod.IsLustreKmodInstalled(*enableLegacyLustrePort)
-		if err != nil {
-			klog.Fatal(err)
-		}
-
-		if isInstalled {
-			klog.Info("Lustre kernel module already installed. Using the network interface specified in LNET parameters.")
-
-			// Check if the current configuration matches the expectation.
-			expectedNetwork := kmod.DefaultLnetNetwork
-			if !effectiveDisableMultiNIC {
-				expectedNetwork = fmt.Sprintf("tcp0(%s)", strings.Join(nics, ","))
-			}
-
-			nics, err = kmod.GetLnetNetwork(expectedNetwork)
-			if err != nil {
-				klog.Fatalf("Failed to get LNET network parameters: %v", err)
-			}
-		} else if !*disableKmodInstall {
-			switch hostOS {
-			case "cos":
-				err = kmod.InstallLustreKmodOnCos(ctx, *enableLegacyLustrePort, customModuleArgs, nics, effectiveDisableMultiNIC)
-				if err != nil {
-					klog.Fatalf("Failed to install lustre kernel modules on COS: %v", err)
-				}
-			case "ubuntu":
-				// TODO(samhalim): Add function for kmod install on Ubuntu Nodes
-			case "windows":
-				klog.Warning("Lustre kernel modules are not supported on Windows nodes.")
-			default:
-				klog.Fatalf("Unsupported or unknown Host OS: %q. Cannot perform Lustre kernel module installation", hostOS)
-			}
 		}
 
 		// Set up host proxy and start the upcall IPC server only on COS nodes.
@@ -179,22 +102,22 @@ func main() {
 			}()
 		}
 
-		if !effectiveDisableMultiNIC && metrics.IsGKEComponentVersionAvailable() {
-			if err := mm.EmitUsingMultiNic(); err != nil {
-				klog.Errorf("Failed to emit GKE component version: %v", err)
+		klog.Info("Retrieving the network interface specified in LNET parameters.")
+		// Pass an empty string as expected network because the kmod-installer initContainer is responsible
+		// for configuring multi-NIC and loading the module. CSI driver will just read the actual config.
+		nics, err := kmod.GetLnetNetwork("")
+		if err != nil {
+			klog.Fatalf("Failed to get LNET network parameters: %v", err)
+		}
+		// additional NICs are any additional NICs that are not default (eth0).
+		// These NICs will require additional setup for multi nic feature.
+		additionalNics := []string{}
+		for _, nic := range nics {
+			if nic != "eth0" {
+				additionalNics = append(additionalNics, nic)
 			}
 		}
 
-		// additional NICs are any additional NICs that are not default (eth0).
-		// These NICs will additional setup for multi nic feature.
-		additionalNics := []string{}
-		if !effectiveDisableMultiNIC {
-			for _, nic := range nics {
-				if nic != "eth0" {
-					additionalNics = append(additionalNics, nic)
-				}
-			}
-		}
 		klog.V(4).Infof("Additional nic(s) %v on Node %v", additionalNics, *nodeID)
 		config.AdditionalNics = additionalNics
 	}

--- a/cmd/kmod_installer/Dockerfile
+++ b/cmd/kmod_installer/Dockerfile
@@ -1,0 +1,37 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM --platform=$BUILDPLATFORM google-go.pkg.dev/golang:1.26.2@sha256:1bee769a7a50eea7730ac31f75182ae2614f50a70902407312db390a7c7cb2ff AS builder
+
+ARG STAGINGVERSION
+ARG TARGETARCH
+
+WORKDIR /go/src/github.com/GoogleCloudPlatform/lustre-csi-driver
+ADD . .
+RUN make kmod_installer GOARCH=${TARGETARCH} BINDIR=/bin
+
+FROM gke.gcr.io/debian-base:bookworm-v1.0.7-gke.2
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN clean-install bash
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    kmod \
+    openssl \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=gcr.io/cos-cloud/cos-dkms:v0.3.12 /usr/bin/cos-dkms /usr/bin/cos-dkms
+COPY --from=builder /bin/lustre-kmod-installer /usr/bin/lustre-kmod-installer
+
+ENTRYPOINT ["/usr/bin/lustre-kmod-installer"]

--- a/cmd/kmod_installer/main.go
+++ b/cmd/kmod_installer/main.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/lustre-csi-driver/pkg/cloud_provider/metadata"
+	kmod "github.com/GoogleCloudPlatform/lustre-csi-driver/pkg/kmod_installer"
+	"github.com/GoogleCloudPlatform/lustre-csi-driver/pkg/network"
+	"k8s.io/klog/v2"
+)
+
+var (
+	nodeID                 = flag.String("nodeid", "", "Node ID")
+	enableLegacyLustrePort = flag.Bool("enable-legacy-lustre-port", false, "If set to true, configure the legacy Lustre LNet port")
+	disableMultiNIC        = flag.Bool("disable-multi-nic", false, "If set to true, multi-NIC support is disabled and the driver will only use the default NIC (eth0)")
+
+	// customModuleArgs contains custom module-args arguments for cos-dkms installation provided by user.
+	customModuleArgs stringSlice
+)
+
+type stringSlice []string
+
+func (s *stringSlice) String() string {
+	return strings.Join(*s, ", ")
+}
+
+func (s *stringSlice) Set(value string) error {
+	*s = append(*s, value)
+	return nil
+}
+
+func main() {
+	klog.InitFlags(nil)
+	flag.Var(&customModuleArgs, "custom-module-args", "Custom module-args for cos-dkms install command. (Can be specified multiple times).")
+	flag.Parse()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if *nodeID == "" {
+		klog.Fatalf("nodeid flag cannot be empty")
+	}
+
+	klog.Infof("Starting Lustre kernel module installer for node %s", *nodeID)
+
+	meta, err := metadata.NewMetadataService(ctx)
+	if err != nil {
+		klog.Fatalf("Failed to set up metadata service: %v", err)
+	}
+
+	netlinker := network.NewNetlink()
+	nodeClient := network.NewK8sClient()
+	networkIntf := network.Manager(netlinker, nodeClient, meta)
+
+	nics, err := networkIntf.GetStandardNICs()
+	if err != nil {
+		klog.Fatalf("Failed to get standard NIC names: %v", err)
+	}
+	if len(nics) == 0 {
+		klog.Fatal("No standard NICs (gve, idpf, or virtio_net) found")
+	}
+
+	effectiveDisableMultiNIC, err := networkIntf.CheckDisableMultiNIC(ctx, *nodeID, nics, *disableMultiNIC)
+	if err != nil {
+		klog.Fatalf("Failed to check multi-NIC status: %v", err)
+	}
+
+	// Check if the kernel modules are already installed.
+	isInstalled, err := kmod.IsLustreKmodInstalled(*enableLegacyLustrePort)
+	if err != nil {
+		klog.Fatalf("Lustre kernel module installation check failed: %v", err)
+	}
+
+	if isInstalled {
+		// Check if the current configuration matches the expectation.
+		expectedNetwork := kmod.DefaultLnetNetwork
+		if !effectiveDisableMultiNIC {
+			expectedNetwork = fmt.Sprintf("tcp0(%s)", strings.Join(nics, ","))
+		}
+
+		if _, err = kmod.GetLnetNetwork(expectedNetwork); err != nil {
+			klog.Fatalf("Failed to get LNET network parameters: %v", err)
+		}
+
+		klog.Info("Lustre kernel module is already installed. Exiting successfully.")
+		return
+	}
+
+	klog.Info("Lustre kernel module is not installed. Proceeding with installation.")
+
+	hostOS, err := kmod.HostOSFromNodeLabel(ctx, *nodeID, nodeClient)
+	if err != nil {
+		klog.Fatalf("Failed to read OS Host Info: %v", err)
+	}
+
+	switch hostOS {
+	case "cos":
+		err = kmod.InstallLustreKmodOnCos(ctx, *enableLegacyLustrePort, customModuleArgs, nics, effectiveDisableMultiNIC)
+		if err != nil {
+			klog.Fatalf("Failed to install lustre kernel modules on COS: %v", err)
+		}
+	case "ubuntu":
+		// TODO(samhalim): Add function for kmod install on Ubuntu Nodes.
+	case "windows":
+		klog.Warning("Lustre kernel modules are not supported on Windows nodes.")
+	default:
+		klog.Fatalf("Unsupported or unknown Host OS: %q. Cannot perform Lustre kernel module installation", hostOS)
+	}
+
+	klog.Info("Successfully installed Lustre kernel modules.")
+}

--- a/deploy/base/node/node.yaml
+++ b/deploy/base/node/node.yaml
@@ -42,6 +42,25 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
         cloud.google.com/gke-os-distribution: cos
+      initContainers:
+        - name: lustre-kmod-installer
+          securityContext:
+            privileged: true
+          image: gke.gcr.io/lustre-kmod-installer
+          imagePullPolicy: Always
+          args:
+            - --v=5
+            - --nodeid=$(KUBE_NODE_NAME)
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: host-etc
+              mountPath: /host_etc/lsb-release
+            - name: host-modules
+              mountPath: /host_modules
       containers:
         - name: lustre-csi-driver
           securityContext:
@@ -71,10 +90,6 @@ spec:
               mountPropagation: "Bidirectional"
             - name: socket-dir
               mountPath: /csi
-            - name: host-etc
-              mountPath: /host_etc/lsb-release
-            - name: host-modules
-              mountPath: /host_modules
             - name: host-udev
               mountPath: /host_etc_udev
         - name: csi-driver-registrar
@@ -125,9 +140,6 @@ spec:
         - name: host-modules
           hostPath:
             path: /lib/modules
-        - name: dev
-          hostPath:
-            path: /dev
         - name: host-udev
           hostPath:
             path: /etc/udev


### PR DESCRIPTION
Reintroduce lustre-kmod-installer as a Golang-based initContainer.

Tested/verified by @tyuchn. Also verified in Ubuntu support PR: 
https://github.com/GoogleCloudPlatform/lustre-csi-driver/pull/491
<img width="2588" height="544" alt="image" src="https://github.com/user-attachments/assets/7f1f5eb2-4ac5-46ca-9691-2e4dcd5af595" />
