### PR TITLE
feat: implement IAM NodePublishVolume lifecycle and global mount

### DIFF
--- a/deploy/base/node/node.yaml
+++ b/deploy/base/node/node.yaml
@@ -88,6 +88,9 @@ spec:
             - name: kubelet-dir
               mountPath: /var/lib/kubelet
               mountPropagation: "Bidirectional"
+            - name: lustre-dir
+              mountPath: /var/lib/lustre
+              mountPropagation: "Bidirectional"
             - name: socket-dir
               mountPath: /csi
             - name: host-udev
@@ -129,6 +132,10 @@ spec:
           hostPath:
             path: /var/lib/kubelet
             type: Directory
+        - name: lustre-dir
+          hostPath:
+            path: /var/lib/lustre
+            type: DirectoryOrCreate
         - name: socket-dir
           hostPath:
             path: /var/lib/kubelet/plugins/lustre.csi.storage.gke.io/

--- a/deploy/base/setup/csi_driver.yaml
+++ b/deploy/base/setup/csi_driver.yaml
@@ -18,3 +18,7 @@ metadata:
   name: lustre.csi.storage.gke.io
 spec:
   attachRequired: false
+  podInfoOnMount: true
+  requiresRepublish: true
+  tokenRequests:
+    - audience: <PROJECT_ID>.svc.id.goog

--- a/examples/pre-prov/preprov-iam-pod.yaml
+++ b/examples/pre-prov/preprov-iam-pod.yaml
@@ -1,0 +1,55 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: lustre-iam-sa
+  namespace: default
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: lustre-iam-pod-a
+  namespace: default
+spec:
+  serviceAccountName: lustre-iam-sa
+  containers:
+    - name: nginx
+      image: nginx
+      volumeMounts:
+        - mountPath: /lustre_volume
+          name: mypvc
+  volumes:
+    - name: mypvc
+      persistentVolumeClaim:
+        claimName: preprov-pvc-iam
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: lustre-iam-pod-b
+  namespace: default
+spec:
+  serviceAccountName: lustre-iam-sa
+  containers:
+    - name: nginx
+      image: nginx
+      volumeMounts:
+        - mountPath: /lustre_volume
+          name: mypvc
+  volumes:
+    - name: mypvc
+      persistentVolumeClaim:
+        claimName: preprov-pvc-iam

--- a/examples/pre-prov/preprov-pvc-pv-iam.yaml
+++ b/examples/pre-prov/preprov-pvc-pv-iam.yaml
@@ -1,0 +1,49 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: preprov-pv-iam
+spec:
+  storageClassName: ""
+  capacity:
+    storage: 9000Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  volumeMode: Filesystem
+  claimRef:
+    namespace: default
+    name: preprov-pvc-iam
+  csi:
+    driver: lustre.csi.storage.gke.io
+    volumeHandle: <project-id>/<instance-location>/<instance-name> # Modify this to use the project, zone, and managed lustre instance name.
+    volumeAttributes:
+      ip: ${EXISTING_LUSTRE_IP_ADDRESS} # The IP address of the existing Lustre instance.
+      filesystem: ${EXISTING_LUSTRE_FSNAME} # The filesystem name of the existing Lustre instance.
+      iamAccessControlEnabled: "true" # Enables IAM access control via Workload Identity.
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: preprov-pvc-iam
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  volumeName: preprov-pv-iam
+  resources:
+    requests:
+      storage: 9000Gi

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -18,8 +18,10 @@ package driver
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -41,7 +43,18 @@ const (
 	initialRouteTableID = 100
 )
 
-var mountPointRegex = regexp.MustCompile(`^(.+)@tcp:/([^/]+)$`)
+const (
+	keyServiceAccount = "csi.storage.k8s.io/serviceAccount.name"
+	keyPodName        = "csi.storage.k8s.io/pod.name"
+	keyPodNamespace   = "csi.storage.k8s.io/pod.namespace"
+	keyServiceToken   = "csi.storage.k8s.io/serviceAccount.tokens"
+	keyPodUID         = "csi.storage.k8s.io/pod.uid"
+)
+
+var (
+	GlobalMountRoot = "/var/lib/lustre/mounts"
+	mountPointRegex = regexp.MustCompile(`^(.+)@tcp:/([^/]+)$`)
+)
 
 type nodeServer struct {
 	// Embed UnimplementedIdentityServer to ensure the driver returns Unimplemented for any
@@ -125,7 +138,7 @@ func (s *nodeServer) NodeStageVolume(_ context.Context, req *csi.NodeStageVolume
 	}
 
 	if err := s.driver.validateVolumeCapabilities([]*csi.VolumeCapability{req.GetVolumeCapability()}); err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+		return nil, status.Errorf(codes.InvalidArgument, "Volume capability validation failed: %v", err)
 	}
 
 	if acquired := s.volumeLocks.TryAcquire(target); !acquired {
@@ -164,30 +177,9 @@ func (s *nodeServer) NodeStageVolume(_ context.Context, req *csi.NodeStageVolume
 		return nil, status.Errorf(codes.AlreadyExists, "A mountpoint with the same lustre filesystem name %q already exists on node %s. Please mount different lustre filesystems", fsname, nodeName)
 	}
 
-	// Check if multi-nic is enabled by checking if there are additional NICs.
-	if len(s.driver.config.AdditionalNics) > 0 {
-		netlinker := network.NewNetlink()
-		nodeClient := network.NewK8sClient()
-		networkIntf := network.Manager(netlinker, nodeClient, s.driver.config.MetadataService)
-		klog.V(4).Infof("Multi Nic feature is enabled and will configure route for Lustre instance: %v, IP: %v", volumeID, source)
-		nics := s.driver.config.AdditionalNics
-		for _, nicName := range nics {
-			// Get NIC IP Addr
-			nicIPAddr, err := networkIntf.GetNICIPAddr(nicName)
-			if err != nil {
-				return nil, status.Errorf(codes.Internal, "Could not get NIC IP address: %v", err)
-			}
-			// Find Table ID for NIC
-			tableID, err := networkIntf.FindNextFreeTableID(initialRouteTableID, nicIPAddr)
-			if err != nil {
-				return nil, status.Errorf(codes.Internal, "Error trying to find a free Table ID: %v", err)
-			}
-			// Configure route for NIC & Lustre instance.
-			err = networkIntf.ConfigureRoute(nicName, ip, tableID)
-			if err != nil {
-				return nil, status.Errorf(codes.Internal, "Route configuration for Multi-NIC failed: %v", err)
-			}
-		}
+	// Setup Multi-NIC routing
+	if err := s.setUpMultiNIC(volumeID, ip); err != nil {
+		return nil, err
 	}
 
 	klog.V(5).Infof("NodeStageVolume creating dir %s on node %s", target, nodeName)
@@ -274,6 +266,13 @@ func (s *nodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishVo
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
+	vc, err := normalizeVolumeContext(req.GetVolumeContext())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	isIAM := strings.EqualFold(vc[normalize(keyIAMAccessControlEnabled)], "true")
+
 	if acquired := s.volumeLocks.TryAcquire(targetPath); !acquired {
 		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, targetPath)
 	}
@@ -298,44 +297,34 @@ func (s *nodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishVo
 		}
 	}
 
+	podName := vc[normalize(keyPodName)]
+	podNamespace := vc[normalize(keyPodNamespace)]
 	nodeName := s.driver.config.NodeID
 
-	mounted, err := s.isMounted(targetPath)
-	if err != nil {
-		return nil, err
-	}
-
-	if mounted {
-		if err := setVolumeOwnershipTopLevel(volumeID, targetPath, fsGroup, ro); err != nil {
-			klog.Infof("setVolumeOwnershipTopLevel failed for volume %q, path %q, fsGroup %q, cleaning up mount point on node %s", volumeID, targetPath, fsGroup, nodeName)
-			if unmntErr := mount.CleanupMountPoint(targetPath, s.mounter, false /* extensiveMountPointCheck */); unmntErr != nil {
-				klog.Errorf("Unmount %q failed on node %s: %v", targetPath, nodeName, unmntErr.Error())
-			}
-
-			return nil, status.Error(codes.Internal, err.Error())
-		}
-
-		return &csi.NodePublishVolumeResponse{}, nil
-	}
-
-	klog.V(5).Infof("NodePublishVolume creating dir %s on node %s", targetPath, nodeName)
+	klog.V(5).Infof("NodePublishVolume creating target dir %s on node %s for pod %s/%s", targetPath, nodeName, podNamespace, podName)
 	if err := makeDir(targetPath); err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not create dir %q on node %s: %v", targetPath, nodeName, err)
 	}
 
-	if err := s.mounter.MountSensitiveWithoutSystemd(stagingTargetPath, targetPath, "lustre", mountOptions, nil); err != nil {
-		klog.Errorf("Mount %q failed on node %s, cleaning up", targetPath, nodeName)
-		if unmntErr := mount.CleanupMountPoint(targetPath, s.mounter, false /* extensiveMountPointCheck */); unmntErr != nil {
-			klog.Errorf("Unmount %q failed on node %s: %v", targetPath, nodeName, unmntErr.Error())
-		}
-
-		return nil, status.Errorf(codes.Internal, "mount %q failed on node %s: %v", targetPath, nodeName, err.Error())
+	targetMounted, err := s.isMounted(targetPath)
+	if err != nil {
+		return nil, err
 	}
 
-	klog.V(4).Infof("NodePublishVolume successfully mounted %s on node %s", targetPath, nodeName)
+	if isIAM {
+		if err := s.publishIAMVolume(volumeID, targetPath, targetMounted, vc, mountOptions, volCap); err != nil {
+			return nil, err
+		}
+	} else if !targetMounted {
+		// For non-IAM volumes, perform a bind mount from staging path to target path.
+		klog.V(5).Infof("NodePublishVolume: bind mounting staging path %s to target path %s", stagingTargetPath, targetPath)
+		if err := s.mounter.MountSensitiveWithoutSystemd(stagingTargetPath, targetPath, "lustre", mountOptions, nil); err != nil {
+			return nil, status.Errorf(codes.Internal, "Legacy bind mount failed: %v", err)
+		}
+	}
 
 	if err := setVolumeOwnershipTopLevel(volumeID, targetPath, fsGroup, ro); err != nil {
-		klog.Infof("setVolumeOwnershipTopLevel failed for volume %q, path %q, fsGroup %q, cleaning up mount point on node %s", volumeID, targetPath, fsGroup, nodeName)
+		klog.V(5).Infof("setVolumeOwnershipTopLevel failed for volume %q, path %q, fsGroup %q, cleaning up mount point on node %s", volumeID, targetPath, fsGroup, nodeName)
 		if unmntErr := mount.CleanupMountPoint(targetPath, s.mounter, false /* extensiveMountPointCheck */); unmntErr != nil {
 			klog.Errorf("Unmount %q failed on node %s: %v", targetPath, nodeName, unmntErr.Error())
 		}
@@ -344,6 +333,153 @@ func (s *nodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishVo
 	}
 
 	return &csi.NodePublishVolumeResponse{}, nil
+}
+
+// publishIAMVolume manages the global mount, token lifecycle, reference counting,
+// and bind mounting for IAM-enabled volumes.
+func (s *nodeServer) publishIAMVolume(volumeID, targetPath string, targetMounted bool, vc map[string]string, mountOptions []string, volCap *csi.VolumeCapability) error {
+	podUID := vc[normalize(keyPodUID)]
+	namespace := vc[normalize(keyPodNamespace)]
+	saName := vc[normalize(keyServiceAccount)]
+
+	if len(podUID) == 0 {
+		return status.Errorf(codes.InvalidArgument, "Pod UID not provided for %s", volumeID)
+	}
+
+	if len(namespace) == 0 {
+		return status.Errorf(codes.InvalidArgument, "Pod namespace not provided for %s", volumeID)
+	}
+	if len(saName) == 0 {
+		return status.Errorf(codes.InvalidArgument, "Service account name not provided for %s", volumeID)
+	}
+
+	principal := fmt.Sprintf("%s/%s", namespace, saName)
+	key := computeHash(volumeID + principal)
+	globalMountPath := filepath.Join(GlobalMountRoot, key, "mount")
+
+	// Acquire lock on the global key to serialize mounting for the same IAM role.
+	if acquired := s.volumeLocks.TryAcquire(key); !acquired {
+		return status.Errorf(codes.Aborted, "Operation exists for key %s", key)
+	}
+	defer s.volumeLocks.Release(key)
+
+	klog.V(5).Infof("publishIAMVolume: Workload Identity principal %q (hash key %q)", principal, key)
+
+	if err := makeGlobalDirs(key); err != nil {
+		return status.Errorf(codes.Internal, "Failed to make global directories for key %s: %v", key, err)
+	}
+	klog.V(5).Infof("publishIAMVolume: Verified global directory under %s", filepath.Join(GlobalMountRoot, key))
+
+	// Parse and update the service token file for Lustre client authentication.
+	projectID := s.driver.config.MetadataService.GetProject()
+	audience := fmt.Sprintf("%s.svc.id.goog", projectID)
+
+	tokenJSON, ok := vc[normalize(keyServiceToken)]
+	if !ok {
+		return status.Errorf(codes.InvalidArgument, "token not found for IAM volume %s", volumeID)
+	}
+
+	token, err := parseToken(tokenJSON, audience)
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "failed to parse token for key %s: %v", key, err)
+	}
+
+	if err := updateTokenFile(key, token); err != nil {
+		klog.Errorf("Failed to update token file for key %s: %v", key, err)
+		return status.Errorf(codes.Internal, "failed to update token file: %v", err)
+	}
+	klog.V(4).Infof("publishIAMVolume: Successfully parsed and updated token file at %s", filepath.Join(GlobalMountRoot, key, "token"))
+
+	// Mount the global path if not already mounted.
+	globalMounted, err := s.isMounted(globalMountPath)
+	if err != nil {
+		return err
+	}
+
+	if !globalMounted {
+		if err := s.mountGlobalIAM(volumeID, globalMountPath, principal, key, vc, volCap); err != nil {
+			return err
+		}
+	}
+
+	// Record pod reference per volume to safely manage unmounting during teardown.
+	if err := addPodReference(key, podUID, volumeID); err != nil {
+		return status.Errorf(codes.Internal, "Failed to add pod reference: %v", err)
+	}
+
+	if !targetMounted {
+		klog.Infof("Bind mounting %s to %s", globalMountPath, targetPath)
+		if err := s.mounter.MountSensitiveWithoutSystemd(globalMountPath, targetPath, "lustre", mountOptions, nil); err != nil {
+			// Clean up the pod reference if the bind mount fails to prevent stale references.
+			if err := removePodReference(key, podUID); err != nil {
+				klog.Errorf("Failed to clean up pod reference for pod %s, volume %s: %v", podUID, volumeID, err)
+			}
+			if unmntErr := mount.CleanupMountPoint(targetPath, s.mounter, false /* extensiveMountPointCheck */); unmntErr != nil {
+				klog.Errorf("Failed to clean up target mount point %q: %v", targetPath, unmntErr)
+			}
+			return status.Errorf(codes.Internal, "Bind mount failed for volume %q to target path %q: %v", volumeID, targetPath, err)
+		}
+	}
+
+	return nil
+}
+
+// mountGlobalIAM parses target storage endpoints, configures multi-NIC routing,
+// and mounts the Lustre instance to the per-principal global mount path.
+func (s *nodeServer) mountGlobalIAM(volumeID, globalMountPath, principal, key string, vc map[string]string, volCap *csi.VolumeCapability) error {
+	ip := vc[normalize(keyInstanceIP)]
+	fsname := vc[normalize(keyFilesystem)]
+	mountPoint := vc[normalize(keyMountPoint)]
+
+	if len(mountPoint) != 0 {
+		var err error
+		ip, fsname, err = parseMountPoint(mountPoint)
+		if err != nil {
+			return status.Error(codes.InvalidArgument, err.Error())
+		}
+	}
+
+	if len(ip) == 0 {
+		return status.Error(codes.InvalidArgument, "Lustre instance IP is not provided")
+	}
+
+	if len(fsname) == 0 {
+		return status.Error(codes.InvalidArgument, "Lustre filesystem name is not provided")
+	}
+
+	nodeName := s.driver.config.NodeID
+
+	// Configure multi-NIC routing for IAM volumes since NodeStageVolume is bypassed.
+	if err := s.setUpMultiNIC(volumeID, ip); err != nil {
+		return err
+	}
+
+	// Perform secure mount with Workload Identity user credentials.
+	source := fmt.Sprintf("%s@tcp:/%s", ip, fsname)
+	userOpt := fmt.Sprintf("user=gke-wi://%s+%s", principal, key)
+	iamMountOptions := []string{userOpt}
+
+	if m := volCap.GetMount(); m != nil {
+		for _, f := range m.GetMountFlags() {
+			if !hasOption(iamMountOptions, f) {
+				iamMountOptions = append(iamMountOptions, f)
+			}
+		}
+	}
+
+	klog.V(5).Infof("mountGlobalIAM mounting volume %s to path %s on node %s with mountOptions %v", volumeID, globalMountPath, nodeName, iamMountOptions)
+	if err := s.mounter.MountSensitiveWithoutSystemd(source, globalMountPath, "lustre", iamMountOptions, nil); err != nil {
+		klog.Errorf("Mount %q failed on node %s for principal %s, cleaning up", globalMountPath, nodeName, principal)
+		if unmntErr := mount.CleanupMountPoint(globalMountPath, s.mounter, false /* extensiveMountPointCheck */); unmntErr != nil {
+			klog.Errorf("Unmount %q failed on node %s for principal %s: %v", globalMountPath, nodeName, principal, unmntErr.Error())
+		}
+
+		return status.Errorf(codes.Internal, "Could not mount %q at %q on node %s: %v", source, globalMountPath, nodeName, err)
+	}
+
+	klog.V(4).Infof("mountGlobalIAM successfully mounted volume %v for principal %s to path %s on node %s", volumeID, principal, globalMountPath, nodeName)
+
+	return nil
 }
 
 func (s *nodeServer) NodeUnpublishVolume(_ context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
@@ -378,6 +514,33 @@ func (s *nodeServer) NodeUnpublishVolume(_ context.Context, req *csi.NodeUnpubli
 	}
 
 	return &csi.NodeUnpublishVolumeResponse{}, nil
+}
+
+func (s *nodeServer) setUpMultiNIC(volumeID, ip string) error {
+	if len(s.driver.config.AdditionalNics) == 0 {
+		return nil
+	}
+
+	netlinker := network.NewNetlink()
+	nodeClient := network.NewK8sClient()
+	networkIntf := network.Manager(netlinker, nodeClient, s.driver.config.MetadataService)
+	klog.V(4).Infof("Multi Nic feature is enabled and will configure route for Lustre instance: %s, IP: %s", volumeID, ip)
+	nics := s.driver.config.AdditionalNics
+	for _, nicName := range nics {
+		nicIPAddr, err := networkIntf.GetNICIPAddr(nicName)
+		if err != nil {
+			return status.Errorf(codes.Internal, "Could not get NIC IP address: %v", err)
+		}
+		tableID, err := networkIntf.FindNextFreeTableID(initialRouteTableID, nicIPAddr)
+		if err != nil {
+			return status.Errorf(codes.Internal, "Error trying to find a free Table ID: %v", err)
+		}
+		err = networkIntf.ConfigureRoute(nicName, ip, tableID)
+		if err != nil {
+			return status.Errorf(codes.Internal, "Route configuration for Multi-NIC failed: %v", err)
+		}
+	}
+	return nil
 }
 
 func (s *nodeServer) NodeGetVolumeStats(_ context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
@@ -617,5 +780,66 @@ func setVolumeOwnershipTopLevel(volumeID, dir, fsGroup string, readOnly bool) er
 	}
 	klog.InfoS("NodePublishVolume successfully changed ownership and permissions of top-level directory", "volume", volumeID, "path", dir, "fsGroup", fsGroup)
 
+	return nil
+}
+
+// Global Mount Helpers
+
+func makeGlobalDirs(key string) error {
+	mountPath := filepath.Join(GlobalMountRoot, key, "mount")
+	refsPath := filepath.Join(GlobalMountRoot, key, "refs")
+	if err := makeDir(mountPath); err != nil {
+		return err
+	}
+	if err := makeDir(refsPath); err != nil {
+		return err
+	}
+	return nil
+}
+
+func updateTokenFile(key, token string) error {
+	tokenPath := filepath.Join(GlobalMountRoot, key, "token")
+	tmpPath := tokenPath + ".tmp"
+	// Write to a temporary file first to ensure atomic update and avoid race conditions with the upcall binary.
+	if err := os.WriteFile(tmpPath, []byte(token), 0600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, tokenPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}
+
+func parseToken(tokenJSON, audience string) (string, error) {
+	// Format: {"audience": {"token": "...", "expirationTimestamp": "..."}}
+	var tokens map[string]struct {
+		Token               string `json:"token"`
+		ExpirationTimestamp string `json:"expirationTimestamp"`
+	}
+	if err := json.Unmarshal([]byte(tokenJSON), &tokens); err != nil {
+		return "", err
+	}
+	if t, ok := tokens[audience]; ok {
+		return t.Token, nil
+	}
+	return "", fmt.Errorf("token for audience %q not found", audience)
+}
+
+func addPodReference(key, podUID, volumeID string) error {
+	refPath := filepath.Join(GlobalMountRoot, key, "refs", podUID)
+	if exists, err := pathExists(refPath); err == nil && exists {
+		return nil
+	}
+	// Write volumeID to the ref file to verify ownership during unpublish
+	klog.V(4).Infof("Adding pod reference for pod UID %s, volume %s at %s", podUID, volumeID, refPath)
+	return os.WriteFile(refPath, []byte(volumeID), 0644)
+}
+
+func removePodReference(key, podUID string) error {
+	refPath := filepath.Join(GlobalMountRoot, key, "refs", podUID)
+	if err := os.Remove(refPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove reference file %q: %w", refPath, err)
+	}
 	return nil
 }

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -23,6 +23,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/lustre-csi-driver/pkg/cloud_provider/metadata"
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -51,6 +52,16 @@ var (
 		keyInstanceIP: testIP,
 		keyFilesystem: testFilesystem,
 	}
+
+	testVolumeAttributesIAM = map[string]string{
+		keyInstanceIP:              testIP,
+		keyFilesystem:              testFilesystem,
+		keyPodUID:                  "test-pod-uid",
+		keyServiceAccount:          "test-sa",
+		keyPodNamespace:            "test-ns",
+		keyIAMAccessControlEnabled: "true",
+		keyServiceToken:            `{"test-project.svc.id.goog":{"token":"test-token","expirationTimestamp":"2099-01-01T00:00:00Z"}}`,
+	}
 )
 
 type nodeServerTestEnv struct {
@@ -58,12 +69,32 @@ type nodeServerTestEnv struct {
 	fm *mount.FakeMounter
 }
 
-type fakeBlockingMounter struct {
+type mockMetadataService struct {
+	project string
+	zone    string
+	nics    []metadata.NetworkInterface
+}
+
+func (m *mockMetadataService) GetZone() string {
+	return m.zone
+}
+
+func (m *mockMetadataService) GetProject() string {
+	return m.project
+}
+
+func (m *mockMetadataService) GetNetworkInterfaces() ([]metadata.NetworkInterface, error) {
+	return m.nics, nil
+}
+
+type fakeMounter struct {
 	*mount.FakeMounter
 	// 'operationUnblocker' channel is used to block the execution of the respective function using it.
 	// This is done by sending a channel of empty struct over 'operationUnblocker' channel,
 	// and wait until the tester gives a go-ahead to proceed further in the execution of the function.
 	operationUnblocker chan chan struct{}
+	mountErr           error
+	failTarget         string
 }
 
 type nodeRequestConfig struct {
@@ -77,6 +108,7 @@ func initTestNodeServer(t *testing.T) *nodeServerTestEnv {
 	t.Helper()
 	mounter := &mount.FakeMounter{MountPoints: []mount.MountPoint{}}
 	driver := initTestDriver(t)
+	driver.config.MetadataService = &mockMetadataService{project: "test-project"}
 
 	return &nodeServerTestEnv{
 		ns: newNodeServer(driver, mounter),
@@ -88,6 +120,7 @@ func initBlockingTestNodeServer(t *testing.T, operationUnblocker chan chan struc
 	t.Helper()
 	mounter := newFakeBlockingMounter(operationUnblocker)
 	driver := initTestDriver(t)
+	driver.config.MetadataService = &mockMetadataService{project: "test-project"}
 
 	return &nodeServerTestEnv{
 		ns: newNodeServer(driver, mounter),
@@ -95,17 +128,23 @@ func initBlockingTestNodeServer(t *testing.T, operationUnblocker chan chan struc
 	}
 }
 
-func newFakeBlockingMounter(operationUnblocker chan chan struct{}) *fakeBlockingMounter {
-	return &fakeBlockingMounter{
+func newFakeBlockingMounter(operationUnblocker chan chan struct{}) *fakeMounter {
+	return &fakeMounter{
 		FakeMounter:        &mount.FakeMounter{MountPoints: []mount.MountPoint{}},
 		operationUnblocker: operationUnblocker,
 	}
 }
 
-func (m *fakeBlockingMounter) MountSensitiveWithoutSystemd(source string, target string, fstype string, options []string, sensitiveOptions []string) error {
-	execute := make(chan struct{})
-	m.operationUnblocker <- execute
-	<-execute
+func (m *fakeMounter) MountSensitiveWithoutSystemd(source string, target string, fstype string, options []string, sensitiveOptions []string) error {
+	if m.operationUnblocker != nil {
+		execute := make(chan struct{})
+		m.operationUnblocker <- execute
+		<-execute
+	}
+
+	if m.mountErr != nil && (m.failTarget == "" || target == m.failTarget) {
+		return m.mountErr
+	}
 
 	return m.FakeMounter.MountSensitiveWithoutSystemd(source, target, fstype, options, sensitiveOptions)
 }
@@ -341,7 +380,12 @@ func TestNodeUnstageVolume(t *testing.T) {
 }
 
 func TestNodePublishVolume(t *testing.T) {
-	t.Parallel()
+	// Disable t.Parallel() and redirect GlobalMountRoot to t.TempDir() to avoid
+	// host permission errors.
+	oldRoot := GlobalMountRoot
+	defer func() { GlobalMountRoot = oldRoot }()
+	GlobalMountRoot = t.TempDir()
+
 	defaultPerm := os.FileMode(0o750) + os.ModeDir
 
 	// Setup mount target path
@@ -351,13 +395,15 @@ func TestNodePublishVolume(t *testing.T) {
 		t.Fatalf("Failed to setup target path: %v", err)
 	}
 	stagingTargetPath := filepath.Join(base, "staging")
+	key := computeHash(testVolumeID + "test-ns/test-sa")
+	globalMountPath := filepath.Join(GlobalMountRoot, key, "mount")
 	cases := []struct {
-		name          string
-		mounts        []mount.MountPoint // already existing mounts
-		req           *csi.NodePublishVolumeRequest
-		actions       []mount.FakeAction
-		expectedMount *mount.MountPoint
-		expectErr     bool
+		name           string
+		mounts         []mount.MountPoint // already existing mounts
+		req            *csi.NodePublishVolumeRequest
+		actions        []mount.FakeAction
+		expectedMounts []*mount.MountPoint
+		expectErr      bool
 	}{
 		{
 			name:      "empty request",
@@ -373,8 +419,8 @@ func TestNodePublishVolume(t *testing.T) {
 				VolumeCapability:  testVolumeCapability,
 				VolumeContext:     testVolumeAttributes,
 			},
-			actions:       []mount.FakeAction{{Action: mount.FakeActionMount}},
-			expectedMount: &mount.MountPoint{Device: stagingTargetPath, Path: testTargetPath, Type: "lustre", Opts: []string{"bind"}},
+			actions:        []mount.FakeAction{{Action: mount.FakeActionMount}},
+			expectedMounts: []*mount.MountPoint{{Device: stagingTargetPath, Path: testTargetPath, Type: "lustre", Opts: []string{"bind"}}},
 		},
 		{
 			name:   "valid request already mounted",
@@ -386,7 +432,7 @@ func TestNodePublishVolume(t *testing.T) {
 				VolumeCapability:  testVolumeCapability,
 				VolumeContext:     testVolumeAttributes,
 			},
-			expectedMount: &mount.MountPoint{Device: "/test-device", Path: testTargetPath},
+			expectedMounts: []*mount.MountPoint{{Device: "/test-device", Path: testTargetPath}},
 		},
 		{
 			name: "valid request with user mount options",
@@ -406,9 +452,8 @@ func TestNodePublishVolume(t *testing.T) {
 				},
 				VolumeContext: testVolumeAttributes,
 			},
-			actions: []mount.FakeAction{{Action: mount.FakeActionMount}},
-
-			expectedMount: &mount.MountPoint{Device: stagingTargetPath, Path: testTargetPath, Type: "lustre", Opts: []string{"bind", "foo", "bar"}},
+			actions:        []mount.FakeAction{{Action: mount.FakeActionMount}},
+			expectedMounts: []*mount.MountPoint{{Device: stagingTargetPath, Path: testTargetPath, Type: "lustre", Opts: []string{"bind", "foo", "bar"}}},
 		},
 		{
 			name: "valid request read only",
@@ -420,8 +465,66 @@ func TestNodePublishVolume(t *testing.T) {
 				VolumeContext:     testVolumeAttributes,
 				Readonly:          true,
 			},
-			actions:       []mount.FakeAction{{Action: mount.FakeActionMount}},
-			expectedMount: &mount.MountPoint{Device: stagingTargetPath, Path: testTargetPath, Type: "lustre", Opts: []string{"bind", "ro"}},
+			actions:        []mount.FakeAction{{Action: mount.FakeActionMount}},
+			expectedMounts: []*mount.MountPoint{{Device: stagingTargetPath, Path: testTargetPath, Type: "lustre", Opts: []string{"bind", "ro"}}},
+		},
+		{
+			name: "valid request IAM (Global Mount)",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:          testVolumeID,
+				StagingTargetPath: stagingTargetPath,
+				TargetPath:        testTargetPath,
+				VolumeCapability:  testVolumeCapability,
+				VolumeContext:     testVolumeAttributesIAM,
+			},
+			actions: []mount.FakeAction{{Action: mount.FakeActionMount}, {Action: mount.FakeActionMount}}, // Global + Bind
+			expectedMounts: []*mount.MountPoint{
+				{Device: testDevice, Path: globalMountPath, Type: "lustre", Opts: []string{"user=gke-wi://test-ns/test-sa+" + key}},
+				{Device: testDevice, Path: testTargetPath, Type: "lustre", Opts: []string{"bind"}},
+			},
+		},
+		{
+			name: "valid request IAM with user mount options (Global Mount)",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:          testVolumeID,
+				StagingTargetPath: stagingTargetPath,
+				TargetPath:        testTargetPath,
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{
+							MountFlags: []string{"flock", "noatime"},
+						},
+					},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					},
+				},
+				VolumeContext: testVolumeAttributesIAM,
+			},
+			actions: []mount.FakeAction{{Action: mount.FakeActionMount}, {Action: mount.FakeActionMount}}, // Global + Bind
+			expectedMounts: []*mount.MountPoint{
+				{Device: testDevice, Path: globalMountPath, Type: "lustre", Opts: []string{"user=gke-wi://test-ns/test-sa+" + key, "flock", "noatime"}},
+				{Device: testDevice, Path: testTargetPath, Type: "lustre", Opts: []string{"bind", "flock", "noatime"}},
+			},
+		},
+		{
+			name: "valid request IAM (Token Refresh)",
+			mounts: []mount.MountPoint{
+				{Device: testDevice, Path: globalMountPath, Type: "lustre", Opts: []string{"user=gke-wi://test-ns/test-sa+" + key}},
+				{Device: testDevice, Path: testTargetPath, Type: "lustre", Opts: []string{"bind"}},
+			},
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:          testVolumeID,
+				StagingTargetPath: stagingTargetPath,
+				TargetPath:        testTargetPath,
+				VolumeCapability:  testVolumeCapability,
+				VolumeContext:     testVolumeAttributesIAM,
+			},
+			actions: []mount.FakeAction{},
+			expectedMounts: []*mount.MountPoint{
+				{Device: testDevice, Path: globalMountPath, Type: "lustre", Opts: []string{"user=gke-wi://test-ns/test-sa+" + key}},
+				{Device: testDevice, Path: testTargetPath, Type: "lustre", Opts: []string{"bind"}},
+			},
 		},
 		{
 			name: "empty target path",
@@ -476,7 +579,7 @@ func TestNodePublishVolume(t *testing.T) {
 			t.Errorf("Test %q failed: got success", test.name)
 		}
 
-		validateMountPoint(t, test.name, testEnv.fm, test.expectedMount)
+		validateMountPoint(t, test.name, testEnv.fm, test.expectedMounts...)
 	}
 }
 
@@ -549,9 +652,16 @@ func TestNodeUnpublishVolume(t *testing.T) {
 	}
 }
 
-func validateMountPoint(t *testing.T, name string, fm *mount.FakeMounter, e *mount.MountPoint) {
+func validateMountPoint(t *testing.T, name string, fm *mount.FakeMounter, expectedMounts ...*mount.MountPoint) {
 	t.Helper()
-	if e == nil {
+	var validExpected []*mount.MountPoint
+	for _, e := range expectedMounts {
+		if e != nil {
+			validExpected = append(validExpected, e)
+		}
+	}
+
+	if len(validExpected) == 0 {
 		if len(fm.MountPoints) != 0 {
 			t.Errorf("Test %q failed: got mounts %+v, expected none", name, fm.MountPoints)
 		}
@@ -559,34 +669,36 @@ func validateMountPoint(t *testing.T, name string, fm *mount.FakeMounter, e *mou
 		return
 	}
 
-	if mLen := len(fm.MountPoints); mLen != 1 {
-		t.Errorf("Test %q failed: got %v mounts(%+v), expected %v", name, mLen, fm.MountPoints, 1)
+	if mLen := len(fm.MountPoints); mLen != len(validExpected) {
+		t.Errorf("Test %q failed: got %v mounts(%+v), expected %v", name, mLen, fm.MountPoints, len(validExpected))
 
 		return
 	}
 
-	a := &fm.MountPoints[0]
-	if a.Device != e.Device {
-		t.Errorf("Test %q failed: got device %q, expected %q", name, a.Device, e.Device)
-	}
-	if a.Path != e.Path {
-		t.Errorf("Test %q failed: got path %q, expected %q", name, a.Path, e.Path)
-	}
-	if a.Type != e.Type {
-		t.Errorf("Test %q failed: got type %q, expected %q", name, a.Type, e.Type)
-	}
+	for idx, e := range validExpected {
+		a := &fm.MountPoints[idx]
+		if a.Device != e.Device {
+			t.Errorf("Test %q [%d] failed: got device %q, expected %q", name, idx, a.Device, e.Device)
+		}
+		if a.Path != e.Path {
+			t.Errorf("Test %q [%d] failed: got path %q, expected %q", name, idx, a.Path, e.Path)
+		}
+		if a.Type != e.Type {
+			t.Errorf("Test %q [%d] failed: got type %q, expected %q", name, idx, a.Type, e.Type)
+		}
 
-	aLen := len(a.Opts)
-	eLen := len(e.Opts)
-	if aLen != eLen {
-		t.Errorf("Test %q failed: got opts length %v, expected %v", name, aLen, eLen)
-	}
+		aLen := len(a.Opts)
+		eLen := len(e.Opts)
+		if aLen != eLen {
+			t.Errorf("Test %q [%d] failed: got opts length %v, expected %v", name, idx, aLen, eLen)
+		}
 
-	for i := range a.Opts {
-		aOpt := a.Opts[i]
-		eOpt := e.Opts[i]
-		if aOpt != eOpt {
-			t.Errorf("Test %q failed: got opt %q, expected %q", name, aOpt, eOpt)
+		for i := range a.Opts {
+			aOpt := a.Opts[i]
+			eOpt := e.Opts[i]
+			if aOpt != eOpt {
+				t.Errorf("Test %q [%d] failed: got opt %q, expected %q", name, idx, aOpt, eOpt)
+			}
 		}
 	}
 }
@@ -828,4 +940,410 @@ func verifyFileOwner(path string, uid, gid int) bool {
 	}
 
 	return true
+}
+
+func TestPublishIAMVolume(t *testing.T) {
+	// Isolate package-level global Go directory Root and inject hermetic MetadataService
+	oldRoot := GlobalMountRoot
+	defer func() { GlobalMountRoot = oldRoot }()
+	GlobalMountRoot = t.TempDir()
+
+	testVolumeID := "test-vol-publish-iam"
+	testTargetPath := filepath.Join(t.TempDir(), "target-mount")
+	testPodUID := "pod-uid-1234"
+	testNamespace := "default"
+	testServiceAccount := "lustre-client-sa"
+	testPrincipal := fmt.Sprintf("%s/%s", testNamespace, testServiceAccount)
+	testKey := computeHash(testVolumeID + testPrincipal)
+
+	testGlobalMountPath := filepath.Join(GlobalMountRoot, testKey, "mount")
+	testTokenPath := filepath.Join(GlobalMountRoot, testKey, "token")
+	testRefPath := filepath.Join(GlobalMountRoot, testKey, "refs", testPodUID)
+
+	validTokenJSON := `{"test-project.svc.id.goog": {"token": "jwt-token", "expirationTimestamp": "2027-01-01T00:00:00Z"}}`
+
+	validVC := map[string]string{
+		keyPodUID:         testPodUID,
+		keyPodNamespace:   testNamespace,
+		keyServiceAccount: testServiceAccount,
+		keyServiceToken:   validTokenJSON,
+		keyInstanceIP:     testIP,
+		keyFilesystem:     testFilesystem,
+	}
+
+	cases := []struct {
+		name           string
+		targetMounted  bool
+		existingMounts []mount.MountPoint
+		preCreateRef   bool
+		vc             map[string]string
+		mountErr       error
+		failTarget     string
+		expectedMounts []*mount.MountPoint
+		expectErr      bool
+		expectToken    string
+	}{
+		{
+			name:          "valid initial publish",
+			targetMounted: false,
+			vc:            validVC,
+			expectedMounts: []*mount.MountPoint{
+				{
+					Device: testIP + "@tcp:/" + testFilesystem,
+					Path:   testGlobalMountPath,
+					Type:   "lustre",
+					Opts:   []string{"user=gke-wi://default/lustre-client-sa+" + testKey},
+				},
+				{
+					Device: testIP + "@tcp:/" + testFilesystem, // FakeMounter resolves bind mount source to underlying device
+					Path:   testTargetPath,
+					Type:   "lustre",
+					Opts:   []string{"bind"},
+				},
+			},
+			expectErr:   false,
+			expectToken: "jwt-token",
+		},
+		{
+			name:          "valid republish/token refresh (already mounted)",
+			targetMounted: true,
+			existingMounts: []mount.MountPoint{
+				{Device: testIP + "@tcp:/" + testFilesystem, Path: testGlobalMountPath},
+				{Device: testGlobalMountPath, Path: testTargetPath},
+			},
+			preCreateRef: true,
+			vc: map[string]string{
+				keyPodUID:         testPodUID,
+				keyPodNamespace:   testNamespace,
+				keyServiceAccount: testServiceAccount,
+				keyServiceToken:   `{"test-project.svc.id.goog": {"token": "newer-refreshed-jwt-token"}}`,
+				keyInstanceIP:     testIP,
+				keyFilesystem:     testFilesystem,
+			},
+			expectedMounts: []*mount.MountPoint{
+				{Device: testIP + "@tcp:/" + testFilesystem, Path: testGlobalMountPath},
+				{Device: testGlobalMountPath, Path: testTargetPath},
+			},
+			expectErr:   false,
+			expectToken: "newer-refreshed-jwt-token",
+		},
+		{
+			name: "missing Pod UID",
+			vc: map[string]string{
+				keyPodNamespace:   testNamespace,
+				keyServiceAccount: testServiceAccount,
+			},
+			expectErr: true,
+		},
+		{
+			name: "missing Pod Namespace",
+			vc: map[string]string{
+				keyPodUID:         testPodUID,
+				keyServiceAccount: testServiceAccount,
+			},
+			expectErr: true,
+		},
+		{
+			name: "missing ServiceAccount",
+			vc: map[string]string{
+				keyPodUID:       testPodUID,
+				keyPodNamespace: testNamespace,
+			},
+			expectErr: true,
+		},
+		{
+			name: "missing Workload Identity token",
+			vc: map[string]string{
+				keyPodUID:         testPodUID,
+				keyPodNamespace:   testNamespace,
+				keyServiceAccount: testServiceAccount,
+			},
+			expectErr: true,
+		},
+		{
+			name:          "bind mount failure returns error",
+			targetMounted: false,
+			vc:            validVC,
+			mountErr:      fmt.Errorf("simulated bind mount failure"),
+			failTarget:    testTargetPath,
+			expectErr:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// Wipe GlobalMountRoot cleanly before each run
+			if err := os.RemoveAll(GlobalMountRoot); err != nil {
+				t.Fatalf("Failed to remove global mount root: %v", err)
+			}
+
+			if tc.preCreateRef {
+				if err := makeGlobalDirs(testKey); err != nil {
+					t.Fatalf("Failed to create global dirs: %v", err)
+				}
+				if err := addPodReference(testKey, testPodUID, testVolumeID); err != nil {
+					t.Fatalf("Failed to pre-create ref: %v", err)
+				}
+			}
+
+			fm := &mount.FakeMounter{MountPoints: tc.existingMounts}
+			if fm.MountPoints == nil {
+				fm.MountPoints = []mount.MountPoint{}
+			}
+			mounter := &fakeMounter{FakeMounter: fm, mountErr: tc.mountErr, failTarget: tc.failTarget}
+
+			driver := initTestDriver(t)
+			driver.config.MetadataService = &mockMetadataService{project: "test-project"}
+
+			ns := newNodeServer(driver, mounter).(*nodeServer)
+
+			normalizedVC := make(map[string]string)
+			for k, v := range tc.vc {
+				normalizedVC[normalize(k)] = v
+			}
+
+			err := ns.publishIAMVolume(testVolumeID, testTargetPath, tc.targetMounted, normalizedVC, []string{"bind"}, testVolumeCapability)
+			if (err != nil) != tc.expectErr {
+				t.Fatalf("Test %q: expected error %v, got %v", tc.name, tc.expectErr, err)
+			}
+
+			if !tc.expectErr {
+				validateMountPoint(t, tc.name, fm, tc.expectedMounts...)
+
+				// Verify token file on disk
+				content, err := os.ReadFile(testTokenPath)
+				if err != nil {
+					t.Fatalf("Failed to read token file: %v", err)
+				}
+				if string(content) != tc.expectToken {
+					t.Errorf("Expected token %q, got %q", tc.expectToken, string(content))
+				}
+
+				// Verify pod reference on disk
+				refContent, err := os.ReadFile(testRefPath)
+				if err != nil {
+					t.Fatalf("Failed to read pod reference file: %v", err)
+				}
+				if string(refContent) != testVolumeID {
+					t.Errorf("Expected ref content %q, got %q", testVolumeID, string(refContent))
+				}
+			}
+		})
+	}
+}
+
+func TestParseToken(t *testing.T) {
+	t.Parallel()
+
+	validJSON := `{"test-project.svc.id.goog":{"token":"test-token","expirationTimestamp":"2099-01-01T00:00:00Z"}}`
+
+	cases := []struct {
+		name        string
+		tokenJSON   string
+		audience    string
+		expectToken string
+		expectErr   bool
+	}{
+		{
+			name:        "valid token parsed",
+			tokenJSON:   validJSON,
+			audience:    "test-project.svc.id.goog",
+			expectToken: "test-token",
+			expectErr:   false,
+		},
+		{
+			name:        "audience not found",
+			tokenJSON:   validJSON,
+			audience:    "other-project.svc.id.goog",
+			expectToken: "",
+			expectErr:   true,
+		},
+		{
+			name:        "invalid json",
+			tokenJSON:   `{malformed-json`,
+			audience:    "test-project.svc.id.goog",
+			expectToken: "",
+			expectErr:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			token, err := parseToken(tc.tokenJSON, tc.audience)
+			if (err != nil) != tc.expectErr {
+				t.Fatalf("Test %q: expected error %v, got %v", tc.name, tc.expectErr, err)
+			}
+			if token != tc.expectToken {
+				t.Fatalf("Test %q: expected token %q, got %q", tc.name, tc.expectToken, token)
+			}
+		})
+	}
+}
+
+func TestUpdateTokenFile(t *testing.T) {
+	oldRoot := GlobalMountRoot
+	defer func() { GlobalMountRoot = oldRoot }()
+	GlobalMountRoot = t.TempDir()
+
+	testKey := "test-hash-key"
+	testToken := "secure-jwt-token"
+
+	// Create global layout
+	if err := makeGlobalDirs(testKey); err != nil {
+		t.Fatalf("Failed to create global layout: %v", err)
+	}
+
+	if err := updateTokenFile(testKey, testToken); err != nil {
+		t.Fatalf("updateTokenFile failed: %v", err)
+	}
+
+	tokenPath := filepath.Join(GlobalMountRoot, testKey, "token")
+	info, err := os.Stat(tokenPath)
+	if err != nil {
+		t.Fatalf("Failed to stat token file: %v", err)
+	}
+
+	if info.Mode().Perm() != 0600 {
+		t.Fatalf("Expected token file permission 0600, got %o", info.Mode().Perm())
+	}
+
+	content, err := os.ReadFile(tokenPath)
+	if err != nil {
+		t.Fatalf("Failed to read token file: %v", err)
+	}
+
+	if string(content) != testToken {
+		t.Fatalf("Expected token content %q, got %q", testToken, string(content))
+	}
+}
+
+func TestMountGlobalIAM(t *testing.T) {
+	// Do not use t.Parallel() because we modify GlobalMountRoot
+	oldRoot := GlobalMountRoot
+	defer func() { GlobalMountRoot = oldRoot }()
+	GlobalMountRoot = t.TempDir()
+
+	testVolumeID := "test-vol-iam"
+	testPrincipal := "test-ns/test-sa"
+	testKey := "test-hash-key"
+	testGlobalMountPath := filepath.Join(GlobalMountRoot, testKey, "mount")
+
+	cases := []struct {
+		name          string
+		vc            map[string]string
+		volCap        *csi.VolumeCapability
+		mountErr      error
+		expectedMount *mount.MountPoint
+		expectErr     bool
+	}{
+		{
+			name: "valid direct IP and FSName",
+			vc: map[string]string{
+				keyInstanceIP: testIP,
+				keyFilesystem: testFilesystem,
+			},
+			volCap: testVolumeCapability,
+			expectedMount: &mount.MountPoint{
+				Device: testIP + "@tcp:/" + testFilesystem,
+				Path:   testGlobalMountPath,
+				Type:   "lustre",
+				Opts:   []string{"user=gke-wi://test-ns/test-sa+test-hash-key"},
+			},
+			expectErr: false,
+		},
+		{
+			name: "valid mountPoint parse",
+			vc: map[string]string{
+				keyMountPoint: "10.0.0.1@tcp:/customfs",
+			},
+			volCap: testVolumeCapability,
+			expectedMount: &mount.MountPoint{
+				Device: "10.0.0.1@tcp:/customfs",
+				Path:   testGlobalMountPath,
+				Type:   "lustre",
+				Opts:   []string{"user=gke-wi://test-ns/test-sa+test-hash-key"},
+			},
+			expectErr: false,
+		},
+		{
+			name: "valid with additional mount flags",
+			vc: map[string]string{
+				keyInstanceIP: testIP,
+				keyFilesystem: testFilesystem,
+			},
+			volCap: &csi.VolumeCapability{
+				AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{
+						MountFlags: []string{"foo", "bar"},
+					},
+				},
+				AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER},
+			},
+			expectedMount: &mount.MountPoint{
+				Device: testIP + "@tcp:/" + testFilesystem,
+				Path:   testGlobalMountPath,
+				Type:   "lustre",
+				Opts:   []string{"user=gke-wi://test-ns/test-sa+test-hash-key", "foo", "bar"},
+			},
+			expectErr: false,
+		},
+		{
+			name: "missing IP",
+			vc: map[string]string{
+				keyFilesystem: testFilesystem,
+			},
+			expectErr: true,
+		},
+		{
+			name: "missing FSName",
+			vc: map[string]string{
+				keyInstanceIP: testIP,
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid mountPoint format",
+			vc: map[string]string{
+				keyMountPoint: "invalid-spec-without-at-sign",
+			},
+			expectErr: true,
+		},
+		{
+			name: "mount failure returns error",
+			vc: map[string]string{
+				keyInstanceIP: testIP,
+				keyFilesystem: testFilesystem,
+			},
+			volCap:    testVolumeCapability,
+			mountErr:  fmt.Errorf("simulated kernel mount error"),
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fm := &mount.FakeMounter{MountPoints: []mount.MountPoint{}}
+			mounter := &fakeMounter{FakeMounter: fm, mountErr: tc.mountErr}
+
+			driver := initTestDriver(t)
+			driver.config.MetadataService = &mockMetadataService{project: "test-project"}
+
+			ns := newNodeServer(driver, mounter).(*nodeServer)
+
+			err := ns.mountGlobalIAM(testVolumeID, testGlobalMountPath, testPrincipal, testKey, tc.vc, tc.volCap)
+			if tc.expectErr && err == nil {
+				t.Fatalf("Test %q: expected an error but got none", tc.name)
+			}
+			if !tc.expectErr && err != nil {
+				t.Fatalf("Test %q: unexpected error: %v", tc.name, err)
+			}
+			if !tc.expectErr {
+				validateMountPoint(t, tc.name, fm, tc.expectedMount)
+			}
+		})
+	}
 }

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -18,6 +18,8 @@ package driver
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -143,4 +145,11 @@ func normalize(input string) string {
 	normalized = strings.ToLower(normalized)
 
 	return normalized
+}
+
+// computeHash computes the SHA-256 hash of a string and returns it as a hex-encoded string.
+func computeHash(s string) string {
+	h := sha256.New()
+	h.Write([]byte(s))
+	return hex.EncodeToString(h.Sum(nil))
 }


### PR DESCRIPTION
This change introduces IAM mounting architecture for the Lustre CSI driver:

- **Bypass NodeStageVolume**: For IAM-enabled volumes, NodeStageVolume is entirely bypassed. Staging mounts are skipped to allow pod-level authentication.
- **Global Mount Architecture**: NodePublishVolume establishes a single global physical mount point shared across all Pods that utilize the same hash (volumeID + principal).
- **Disk Lifecycle DB Directories**:
  - mount/: The actual physical global Lustre filesystem mountpoint (/var/lib/lustre/mounts/key/mount), which is then bind-mounted into individual container target paths.
  - token/: Lands the projected KSA JWT directly to /var/lib/lustre/mounts/<key>/token, accessible by the kernel Lustre upcall binary to exchange for GCP access tokens via STS.
  - refs/: Records individual active Pod attachments (/var/lib/lustre/mounts/key/refs/<pod-uid>) to safely track multi-pod sharing and ensure the global mount is only torn down when the exact last Pod unpublishes.
- **Token Refresh & Republish**: Supports long-running workloads by intercepting Kubelet RepublishVolume requests to atomically rotate the token/credentials on disk while maintaining the active global mount.

TAG=agy

Change-Id: I261032ccd1bb6a69daae0059d7896a69709dfd5e