### PR TITLE
Modify gke-release to utilize new lustre-kmod-installer setup (image).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,14 +126,10 @@ generate-spec-yaml:
 		echo "  template:" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
 		echo "    spec:" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
 		echo "      initContainers:" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
-		echo "      - name: disable-loadpin" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
-		echo "        \$$patch: delete" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
-		echo "      - name: install-lustre-mods" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
+		echo "      - name: lustre-kmod-installer" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
 		echo "        \$$patch: delete" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
 		echo "      volumes:" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
 		echo "      - name: host-modules" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
-		echo "        \$$patch: delete" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
-		echo "      - name: dev" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
 		echo "        \$$patch: delete" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
 		echo "      - name: host-etc" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
 		echo "        \$$patch: delete" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \

--- a/deploy/images/gke-release/image.yaml
+++ b/deploy/images/gke-release/image.yaml
@@ -24,10 +24,10 @@ imageTag:
 apiVersion: builtin
 kind: ImageTagTransformer
 metadata:
-  name: imagetag-cos-dkms
+  name: lustre-kmod-installer
 imageTag:
-  name: gcr.io/cos-cloud/cos-dkms
-  newTag: "v0.3.9"
+  name: gke.gcr.io/lustre-kmod-installer
+  newTag: "v0.6.9-gke.4"
 ---
 apiVersion: builtin
 kind: ImageTagTransformer
@@ -35,5 +35,4 @@ metadata:
   name: imagetag-lustre-csi-driver
 imageTag:
   name: gke.gcr.io/lustre-csi-driver
-  newTag: "v0.3.14-gke.1"
-
+  newTag: "v0.6.9-gke.4"

--- a/deploy/overlays/gke-release/node.yaml
+++ b/deploy/overlays/gke-release/node.yaml
@@ -39,59 +39,41 @@ spec:
           type: RuntimeDefault
       priorityClassName: csi-lustre-node
       serviceAccount: lustre-csi-node-sa
-      nodeSelector:
-        kubernetes.io/os: linux
-        cloud.google.com/gke-os-distribution: cos
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+                  - key: cloud.google.com/gke-os-distribution
+                    operator: In
+                    values:
+                      - cos
+                      - ubuntu
       initContainers:
-      - name: disable-loadpin
-        image: gcr.io/cos-cloud/cos-dkms
-        securityContext:
-          privileged: true
-        command: ["/bin/sh", "-c"]
-        args:
-          - |
-            # Disable LoadPin if it's not already disabled
-            if cat /proc/cmdline | grep "loadpin"; then
-              echo "LoadPin has already been disabled. Move to kmod installation."
-            else
-              echo "Sleep 60s until the node is ready"
-              sleep 60
-              echo "LoadPin is not disabled. Disabling LoadPin now."
-              mkdir -p /mnt/disks
-              mount /dev/disk/by-label/EFI-SYSTEM /mnt/disks
-              sed -i -e 's|module.sig_enforce=0|module.sig_enforce=0 loadpin.enforce=0|g' /mnt/disks/efi/boot/grub.cfg
-              umount /mnt/disks
-              echo 1 > /proc/sys/kernel/sysrq
-              echo b > /proc/sysrq-trigger
-            fi
-        volumeMounts:
-        - name: dev
-          mountPath: /dev
-      - name: install-lustre-mods
-        image: gcr.io/cos-cloud/cos-dkms
-        securityContext:
-         privileged: true
-        command: ["/bin/sh", "-c"]
-        args:
-          - |
-            # Install the Lustre client drivers.
-            #
-            # --gcs-bucket: Specifies the GCS bucket containing the driver packages ('cos-default').
-            # --module-version: Sets the lustre client driver version.
-            # --kernelmodulestree: Sets the path to the kernel modules directory on the host ('/host_modules').
-            # --lsb-release-path: Specifies the path to the lsb-release file on the host ('/host_etc/lsb-release').
-            # --insert-on-install: Inserts the module into the kernel after installation.
-            # --module-arg lnet.accept_port=6988: This is crucial for setting the LNET port.
-            #                                     Lustre uses LNET for network communication, and this
-            #                                     parameter configures the port LNET will use. This is
-            #                                     essential for proper communication between Lustre clients
-            #                                     and servers. In this case, we're setting it to 6988.
-            /usr/bin/cos-dkms install lustre-client-drivers --gcs-bucket=cos-default --latest -w 0 --kernelmodulestree=/host_modules --module-arg=lnet.accept_port=6988 --lsb-release-path=/host_etc/lsb-release --insert-on-install --logtostderr
-        volumeMounts:
-        - name: host-etc
-          mountPath: /host_etc/lsb-release
-        - name: host-modules
-          mountPath: /host_modules
+        - name: lustre-kmod-installer
+          securityContext:
+            privileged: true
+          image: gke.gcr.io/lustre-kmod-installer
+          imagePullPolicy: Always
+          args:
+            - --v=5
+            - --nodeid=$(KUBE_NODE_NAME)
+            - --disable-multi-nic=false
+            - --enable-legacy-lustre-port=false
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: host-etc
+              mountPath: /host_etc/lsb-release
+            - name: host-modules
+              mountPath: /host_modules
       containers:
         - name: lustre-csi-driver
           securityContext:
@@ -122,6 +104,10 @@ spec:
               mountPropagation: "Bidirectional"
             - name: socket-dir
               mountPath: /csi
+            - name: host-udev
+              mountPath: /host_etc_udev
+            - name: dev
+              mountPath: /dev
         - name: csi-driver-registrar
           securityContext:
             readOnlyRootFilesystem: true
@@ -166,12 +152,18 @@ spec:
         - name: host-etc
           hostPath:
             path: /etc/lsb-release
+            type: File
         - name: host-modules
           hostPath:
             path: /lib/modules
+        - name: host-udev
+          hostPath:
+            path: /etc/udev
+            type: Directory
         - name: dev
           hostPath:
             path: /dev
+            type: Directory
       # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
       # See "special case". This will tolerate everything. Node component should
       # be scheduled on all nodes.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -42,6 +42,8 @@ limitations under the License.
   >
   > - **For GKE version `1.34.1-gke.236400` or later**: You can use the [Container-Optimized OS with Secure Modules](https://cloud.google.com/kubernetes-engine/security/secure-modules-cos) node image. This image supports installing the Lustre kernel module without needing to disable LoadPin or reboot the node.
   > - **For older versions**: Ensure the node image is **Container-Optimized OS with containerd** (`cos_containerd`). Additionally, verify that [Secure Boot](https://cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes#secure_boot) is disabled in your node pool (it is disabled by default in standard GKE clusters).
+  > > [!IMPORTANT]
+  > > To install the unmanaged Lustre CSI driver, your node pool must be created with [Secure Kernel Module Loading](https://cloud.google.com/kubernetes-engine/security/secure-modules-cos) enabled on non-GPU nodes. This is required because the driver loads Lustre kernel modules dynamically, which COS blocks by default unless Secure Kernel Module Loading is enabled or LoadPin is disabled manually on the node.
 
 - Run the following command to ensure the kubectl context is set up correctly.
 

--- a/helm/lustre-csi-driver/Chart.yaml
+++ b/helm/lustre-csi-driver/Chart.yaml
@@ -29,10 +29,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.12"
+appVersion: "0.4.13"

--- a/helm/lustre-csi-driver/templates/csi-node.yaml
+++ b/helm/lustre-csi-driver/templates/csi-node.yaml
@@ -44,16 +44,20 @@ spec:
       initContainers:
       - name: lustre-kmod-installer
         image: "{{ .Values.image.kmod.repository }}:{{ .Values.image.kmod.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.kmod.pullPolicy | default "Always" }}
         securityContext:
-         privileged: true
+          privileged: true
+        args:
+          - --v=5
+          - --nodeid=$(KUBE_NODE_NAME)
+          - --enable-legacy-lustre-port={{ .Values.image.kmod.enableLegacyLustrePort }}
+          - --disable-multi-nic={{ .Values.image.kmod.disableMultiNic }}
         env:
-        - name: ENABLE_LEGACY_LUSTRE_PORT
-          value: "true"
-        - name: CHECK_LOADPIN
-          value: "true"
+          - name: KUBE_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
         volumeMounts:
-        - name: dev
-          mountPath: /dev
         - name: host-etc
           mountPath: /host_etc/lsb-release
         - name: host-modules
@@ -88,6 +92,10 @@ spec:
               mountPropagation: "Bidirectional"
             - name: socket-dir
               mountPath: /csi
+            - name: host-udev
+              mountPath: /host_etc_udev
+            - name: dev
+              mountPath: /dev
         - name: csi-driver-registrar
           securityContext:
             readOnlyRootFilesystem: true
@@ -136,8 +144,13 @@ spec:
         - name: host-modules
           hostPath:
             path: /lib/modules
+        - name: host-udev
+          hostPath:
+            path: /etc/udev
+            type: Directory
         - name: dev
           hostPath:
             path: /dev
+            type: Directory
       tolerations:
         - operator: Exists

--- a/helm/lustre-csi-driver/values.yaml
+++ b/helm/lustre-csi-driver/values.yaml
@@ -20,12 +20,14 @@
 image:
   lustre:
     repository: "us.gcr.io/gke-release/lustre-csi-driver"
-    tag: v0.4.12-gke.0
+    tag: v0.6.9-gke.4
     pullPolicy: Always
   kmod:
     repository: "us.gcr.io/gke-release/lustre-kmod-installer"
-    tag: v0.4.12-gke.0
+    tag: v0.6.9-gke.4
     pullPolicy: Always
+    enableLegacyLustrePort: false
+    disableMultiNic: false
 
 sidecars:
   image:


### PR DESCRIPTION
Context:
Lustre-kmod-installer no longer uses bash script but is an image which was added to support kernel installation for both COS and Ubuntu. We update gke-release so that it uses this and deprecate old bash script initContainer.