### PR TITLE
docs: fix GKE version typo and update Helm deployment paths in docume…

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,7 +40,7 @@ limitations under the License.
 
   > Ensure that your cluster's node pool version is at least `1.31.5-gke.1299000` or `1.32.1-gke.1673000`.
   >
-  > - **For GKE version `1.34.1-gke.236400` or later**: You can use the [Container-Optimized OS with Secure Modules](https://cloud.google.com/kubernetes-engine/security/secure-modules-cos) node image. This image supports installing the Lustre kernel module without needing to disable LoadPin or reboot the node.
+  > - **For GKE version `1.34.1-gke.2364000` or later**: You can use the [Container-Optimized OS with Secure Modules](https://cloud.google.com/kubernetes-engine/security/secure-modules-cos) node image. This image supports installing the Lustre kernel module without needing to disable LoadPin or reboot the node.
   > - **For older versions**: Ensure the node image is **Container-Optimized OS with containerd** (`cos_containerd`). Additionally, verify that [Secure Boot](https://cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes#secure_boot) is disabled in your node pool (it is disabled by default in standard GKE clusters).
   > > [!IMPORTANT]
   > > To install the unmanaged Lustre CSI driver, your node pool must be created with [Secure Kernel Module Loading](https://cloud.google.com/kubernetes-engine/security/secure-modules-cos) enabled on non-GPU nodes. This is required because the driver loads Lustre kernel modules dynamically, which COS blocks by default unless Secure Kernel Module Loading is enabled or LoadPin is disabled manually on the node.

--- a/helm/README.md
+++ b/helm/README.md
@@ -48,7 +48,7 @@ curl -fsSL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
     - Run the [gsa_setup script](../deploy/base/setup/gsa_setup.sh) to configure the service account:
 
     ```sh
-    ../deploy/base/setup/gsa_setup.sh
+    ./deploy/base/setup/gsa_setup.sh
     ```
 
     - Create a Kubernetes secret from the service account key:
@@ -66,7 +66,7 @@ curl -fsSL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
 3. Install the csi driver using helm
 
     ```sh
-    helm upgrade -i lustre-csi-driver lustre-csi-driver \
+    helm upgrade -i lustre-csi-driver ./helm/lustre-csi-driver \
       --namespace ${NAMESPACE} \
       --set image.lustre.tag="$VERSION"
     ```


### PR DESCRIPTION
This PR fixes a few minor documentation errors in the installation guides to prevent user confusion during setup:

1. **GKE Version Typo:** Fixed a missing zero in the required GKE version (`1.34.1-gke.236400` -> `1.34.1-gke.2364000`) in `docs/installation.md`.
2. **Helm Script Path:** Updated the `gsa_setup.sh` script path in the Helm README from `../deploy/...` to `./deploy/...` to correctly reflect running it from the root of the repository.
3. **Helm Chart Path:** Fixed the `helm upgrade` command to point to the local `./helm/lustre-csi-driver` directory. The previous command (`helm upgrade -i lustre-csi-driver lustre-csi-driver`) caused Helm to search for a remote chart, resulting in the following error:
   `Error: non-absolute URLs should be in form of repo_name/path_to_chart, got: lustre-csi-driver`