### PR TITLE
feat: implement IAM NodeUnpublishVolume lifecycle

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -19,12 +19,14 @@ package driver
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/GoogleCloudPlatform/lustre-csi-driver/pkg/network"
 	"github.com/GoogleCloudPlatform/lustre-csi-driver/pkg/util"
@@ -52,8 +54,10 @@ const (
 )
 
 var (
-	GlobalMountRoot = "/var/lib/lustre/mounts"
-	mountPointRegex = regexp.MustCompile(`^(.+)@tcp:/([^/]+)$`)
+	GlobalMountRoot    = "/var/lib/lustre/mounts"
+	mountPointRegex    = regexp.MustCompile(`^(.+)@tcp:/([^/]+)$`)
+	iamKeyExtractRegex = regexp.MustCompile(`[/\\]([^/\\]+)[/\\]refs[/\\][^/\\]+$`)
+	podUIDRegex        = regexp.MustCompile(`/pods/([^/]+)/volumes`)
 )
 
 type nodeServer struct {
@@ -513,6 +517,10 @@ func (s *nodeServer) NodeUnpublishVolume(_ context.Context, req *csi.NodeUnpubli
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
+	if err := s.cleanUpIAMReference(targetPath); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to clean up IAM reference directories: %v", err)
+	}
+
 	return &csi.NodeUnpublishVolumeResponse{}, nil
 }
 
@@ -841,5 +849,112 @@ func removePodReference(key, podUID string) error {
 	if err := os.Remove(refPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to remove reference file %q: %w", refPath, err)
 	}
+	return nil
+}
+
+func getPodUIDFromTargetPath(path string) (string, error) {
+	// Path: /var/lib/kubelet/pods/<podUID>/volumes/kubernetes.io~csi/<pvName>/mount
+	matches := podUIDRegex.FindStringSubmatch(path)
+	if len(matches) < 2 {
+		return "", fmt.Errorf("could not extract pod UID from path %s", path)
+	}
+	return matches[1], nil
+}
+
+func (s *nodeServer) cleanUpIAMReference(targetPath string) error {
+	podUID, err := getPodUIDFromTargetPath(targetPath)
+	if err != nil {
+		klog.V(5).Infof("Failed to extract pod UID from target path %q (likely non-IAM volume): %v", targetPath, err)
+		return nil
+	}
+
+	// Find all instances of this podUID across all keys using a targeted glob pattern.
+	// This lets the filesystem optimize the search rather than doing nested Go loops.
+	pattern := filepath.Join(GlobalMountRoot, "*", "refs", podUID)
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return fmt.Errorf("failed to glob pod references: %w", err)
+	}
+
+	var errs []error
+	for _, refPath := range matches {
+		klog.Infof("Found IAM pod reference at %s, cleaning up", refPath)
+
+		// Extract the volume key from the matched path using regex
+		match := iamKeyExtractRegex.FindStringSubmatch(refPath)
+		if len(match) < 2 {
+			klog.Errorf("Path %q does not match expected format", refPath)
+			continue
+		}
+		key := match[1]
+
+		// Locks must be released per iteration. Since defer is function-scoped, delegate to a helper method.
+		if err := s.cleanUpIAMReferenceForKey(key, refPath); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
+}
+
+func (s *nodeServer) cleanUpIAMReferenceForKey(key, refPath string) error {
+	// Acquire a lock to prevent races with concurrent mounts.
+	if acquired := s.volumeLocks.TryAcquire(key); !acquired {
+		return fmt.Errorf("could not acquire lock for key %s; operation in progress", key)
+	}
+	defer s.volumeLocks.Release(key)
+
+	// Delete the pod-specific marker file.
+	if err := os.Remove(refPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove pod reference %q: %w", refPath, err)
+	}
+
+	// Attempt to remove the 'refs' directory.
+	// If os.Remove succeeds, this was the last pod using this shared mount key.
+	refsDir := filepath.Join(GlobalMountRoot, key, "refs")
+	var pathErr *os.PathError
+	if err := os.Remove(refsDir); err != nil {
+		// Outcome 1: The directory doesn't exist because another thread already deleted it.
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+
+		// Outcome 2: The directory is still there. This could be syscall.ENOTEMPTY, or a permission/I/O issue.
+		// NOTE: This is Linux-specific. Adjust if Windows support is needed.
+		if errors.As(err, &pathErr) && pathErr.Err == syscall.ENOTEMPTY {
+			klog.V(5).Infof("Global mount for key %s is still shared by other pods", key)
+			return nil
+		}
+
+		return fmt.Errorf("unexpected error checking refs directory %q: %w", refsDir, err)
+	}
+
+	// Outcome 3: If we successfully removed refsDir, this is the last pod. Cleanup the global mount.
+	klog.Infof("No more pod references for key %s. Unmounting global path.", key)
+	globalMountPath := filepath.Join(GlobalMountRoot, key, "mount")
+
+	if notMnt, _ := s.mounter.IsLikelyNotMountPoint(globalMountPath); !notMnt {
+		// Manual unmount to clear transport-shutdown or corrupted states.
+		klog.V(4).Infof("Performing explicit unmount of global path %q", globalMountPath)
+		if err := s.mounter.Unmount(globalMountPath); err != nil {
+			return fmt.Errorf("failed robust unmount of global path %q: %w", globalMountPath, err)
+		}
+	}
+
+	// Cleanup to verify unmount and remove the 'mount' directory.
+	if err := mount.CleanupMountPoint(globalMountPath, s.mounter, false /* extensiveMountPointCheck */); err != nil {
+		return fmt.Errorf("failed standard cleanup for global mount point %q: %w", globalMountPath, err)
+	}
+
+	// Clean up the entire key folder
+	keyDir := filepath.Join(GlobalMountRoot, key)
+	if err := os.RemoveAll(keyDir); err != nil {
+		return fmt.Errorf("failed to clean up global directories for key %s: %v", key, err)
+	}
+
 	return nil
 }

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -652,6 +652,187 @@ func TestNodeUnpublishVolume(t *testing.T) {
 	}
 }
 
+func TestNodeUnpublishVolume_IAM(t *testing.T) {
+	// Reassign GlobalMountRoot to t.TempDir() for isolation.
+	origGlobalMountRoot := GlobalMountRoot
+	GlobalMountRoot = t.TempDir()
+	defer func() { GlobalMountRoot = origGlobalMountRoot }()
+
+	defaultPerm := os.FileMode(0o750) + os.ModeDir
+	testKey := "71ac09669e8a14e7dca05e1bb9ef37802de0448c37bb195c6c1b68a5ff3f2c2e"
+
+	basePath := t.TempDir()
+	stagingTargetPath := filepath.Join(basePath, "staging")
+	_ = stagingTargetPath
+
+	podUID1 := "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d"
+	podUID2 := "b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e"
+
+	targetPath1 := filepath.Join(basePath, "pods", podUID1, "volumes", "kubernetes.io~csi", "vol-a", "mount")
+	targetPath2 := filepath.Join(basePath, "pods", podUID2, "volumes", "kubernetes.io~csi", "vol-b", "mount")
+
+	cases := []struct {
+		name                string
+		targetPath          string
+		targetPodUID        string
+		targetVolumeID      string
+		setupRefs           []string
+		setupGlobalMounted  bool
+		expectGlobalUnmount bool
+		expectKeyDirDeleted bool
+		expectRemainingRefs []string
+		expectErr           bool
+	}{
+		{
+			name:                "successful unpublish with other active pod references remaining",
+			targetPath:          targetPath1,
+			targetPodUID:        podUID1,
+			targetVolumeID:      "vol-a",
+			setupRefs:           []string{podUID1, podUID2},
+			setupGlobalMounted:  true,
+			expectGlobalUnmount: false,
+			expectKeyDirDeleted: false,
+			expectRemainingRefs: []string{podUID2},
+		},
+		{
+			name:                "successful unpublish of last remaining pod (triggers global teardown)",
+			targetPath:          targetPath2,
+			targetPodUID:        podUID2,
+			targetVolumeID:      "vol-b",
+			setupRefs:           []string{podUID2},
+			setupGlobalMounted:  true,
+			expectGlobalUnmount: true,
+			expectKeyDirDeleted: true,
+			expectRemainingRefs: []string{},
+		},
+		{
+			name:                "unpublish non-IAM volume is skipped or handled gracefully",
+			targetPath:          filepath.Join(basePath, "legacy-mount"),
+			targetPodUID:        "",
+			targetVolumeID:      "vol-legacy",
+			setupRefs:           []string{},
+			expectGlobalUnmount: false,
+			expectKeyDirDeleted: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			keyDir := filepath.Join(GlobalMountRoot, testKey)
+			// Make sure to teardown the directory to handle cases where a subtest fails mid run
+			t.Cleanup(func() { _ = os.RemoveAll(keyDir) })
+			if err := os.RemoveAll(keyDir); err != nil {
+				t.Fatalf("failed to clean up key dir: %v", err)
+			}
+
+			// Build existingMounts dynamically using the temporary paths
+			var existingMounts []mount.MountPoint
+			if tc.setupGlobalMounted {
+				existingMounts = append(existingMounts, mount.MountPoint{
+					Device: "10.0.0.1@tcp:/iamfs",
+					Path:   filepath.Join(keyDir, "mount"),
+					Type:   "lustre",
+				})
+			}
+			existingMounts = append(existingMounts, mount.MountPoint{
+				Device: filepath.Join(keyDir, "mount"),
+				Path:   tc.targetPath,
+				Type:   "lustre",
+			})
+
+			if len(tc.setupRefs) > 0 {
+				refsDir := filepath.Join(keyDir, "refs")
+				if err := os.MkdirAll(refsDir, defaultPerm); err != nil {
+					t.Fatalf("Failed to create refs dir: %v", err)
+				}
+				for _, uid := range tc.setupRefs {
+					refPath := filepath.Join(refsDir, uid)
+					if err := os.WriteFile(refPath, []byte(tc.targetVolumeID), 0644); err != nil {
+						t.Fatalf("Failed to write ref file %q: %v", refPath, err)
+					}
+				}
+				globalMntPath := filepath.Join(keyDir, "mount")
+				if err := os.MkdirAll(globalMntPath, defaultPerm); err != nil {
+					t.Fatalf("Failed to create global mount dir: %v", err)
+				}
+			}
+
+			testEnv := initTestNodeServer(t)
+			testEnv.fm.MountPoints = existingMounts
+
+			// Ensure the target path folder itself exists on disk so isMounted and cleanup checks pass
+			if err := os.MkdirAll(tc.targetPath, defaultPerm); err != nil {
+				t.Fatalf("Failed to create target path directory: %v", err)
+			}
+
+			req := &csi.NodeUnpublishVolumeRequest{
+				VolumeId:   tc.targetVolumeID,
+				TargetPath: tc.targetPath,
+			}
+
+			_, err := testEnv.ns.NodeUnpublishVolume(t.Context(), req)
+			if (err != nil) != tc.expectErr {
+				t.Fatalf("NodeUnpublishVolume returned unexpected error: %v", err)
+			}
+
+			// 1. Verify target path is unmounted
+			for _, m := range testEnv.fm.MountPoints {
+				if m.Path == tc.targetPath {
+					t.Errorf("Target path %q was not unmounted", tc.targetPath)
+				}
+			}
+
+			// 2. Verify remaining reference files
+			if !tc.expectKeyDirDeleted {
+				for _, expectedRef := range tc.expectRemainingRefs {
+					refPath := filepath.Join(keyDir, "refs", expectedRef)
+					exists, err := pathExists(refPath)
+					if err != nil || !exists {
+						t.Errorf("Expected reference file %q to remain, but it was missing", refPath)
+					}
+				}
+
+				// Check that deleted references are actually gone
+				if tc.targetPodUID != "" {
+					deletedRefPath := filepath.Join(keyDir, "refs", tc.targetPodUID)
+					exists, err := pathExists(deletedRefPath)
+					if err == nil && exists {
+						t.Errorf("Expected reference file %q to be deleted, but it still exists", deletedRefPath)
+					}
+				}
+			}
+
+			// 3. Verify global mount unmount action
+			globalMntPath := filepath.Join(keyDir, "mount")
+			isGlobalMntActive := false
+			for _, m := range testEnv.fm.MountPoints {
+				if m.Path == globalMntPath {
+					isGlobalMntActive = true
+					break
+				}
+			}
+			if tc.expectGlobalUnmount && isGlobalMntActive {
+				t.Errorf("Expected global mount path %q to be unmounted, but it was still active", globalMntPath)
+			}
+			if !tc.expectGlobalUnmount && tc.setupGlobalMounted && !isGlobalMntActive {
+				t.Errorf("Expected global mount path %q to remain mounted, but it was unmounted", globalMntPath)
+			}
+
+			// 4. Verify state directories cleanup
+			keyDirExists, err := pathExists(keyDir)
+			if err != nil {
+				t.Fatalf("Failed to check if key dir exists: %v", err)
+			}
+			if tc.expectKeyDirDeleted && keyDirExists {
+				t.Errorf("Expected global directory %q to be deleted, but it still exists", keyDir)
+			}
+			if !tc.expectKeyDirDeleted && len(tc.setupRefs) > 0 && !keyDirExists {
+				t.Errorf("Expected global directory %q to remain, but it was deleted", keyDir)
+			}
+		})
+	}
+}
+
 func validateMountPoint(t *testing.T, name string, fm *mount.FakeMounter, expectedMounts ...*mount.MountPoint) {
 	t.Helper()
 	var validExpected []*mount.MountPoint
@@ -1188,7 +1369,7 @@ func TestUpdateTokenFile(t *testing.T) {
 	defer func() { GlobalMountRoot = oldRoot }()
 	GlobalMountRoot = t.TempDir()
 
-	testKey := "test-hash-key"
+	testKey := "71ac09669e8a14e7dca05e1bb9ef37802de0448c37bb195c6c1b68a5ff3f2c2e"
 	testToken := "secure-jwt-token"
 
 	// Create global layout
@@ -1228,7 +1409,7 @@ func TestMountGlobalIAM(t *testing.T) {
 
 	testVolumeID := "test-vol-iam"
 	testPrincipal := "test-ns/test-sa"
-	testKey := "test-hash-key"
+	testKey := "71ac09669e8a14e7dca05e1bb9ef37802de0448c37bb195c6c1b68a5ff3f2c2e"
 	testGlobalMountPath := filepath.Join(GlobalMountRoot, testKey, "mount")
 
 	cases := []struct {
@@ -1250,7 +1431,7 @@ func TestMountGlobalIAM(t *testing.T) {
 				Device: testIP + "@tcp:/" + testFilesystem,
 				Path:   testGlobalMountPath,
 				Type:   "lustre",
-				Opts:   []string{"user=gke-wi://test-ns/test-sa+test-hash-key"},
+				Opts:   []string{"user=gke-wi://test-ns/test-sa+71ac09669e8a14e7dca05e1bb9ef37802de0448c37bb195c6c1b68a5ff3f2c2e"},
 			},
 			expectErr: false,
 		},
@@ -1264,7 +1445,7 @@ func TestMountGlobalIAM(t *testing.T) {
 				Device: "10.0.0.1@tcp:/customfs",
 				Path:   testGlobalMountPath,
 				Type:   "lustre",
-				Opts:   []string{"user=gke-wi://test-ns/test-sa+test-hash-key"},
+				Opts:   []string{"user=gke-wi://test-ns/test-sa+71ac09669e8a14e7dca05e1bb9ef37802de0448c37bb195c6c1b68a5ff3f2c2e"},
 			},
 			expectErr: false,
 		},
@@ -1286,7 +1467,7 @@ func TestMountGlobalIAM(t *testing.T) {
 				Device: testIP + "@tcp:/" + testFilesystem,
 				Path:   testGlobalMountPath,
 				Type:   "lustre",
-				Opts:   []string{"user=gke-wi://test-ns/test-sa+test-hash-key", "foo", "bar"},
+				Opts:   []string{"user=gke-wi://test-ns/test-sa+71ac09669e8a14e7dca05e1bb9ef37802de0448c37bb195c6c1b68a5ff3f2c2e", "foo", "bar"},
 			},
 			expectErr: false,
 		},


### PR DESCRIPTION
This change implements secure unmounting and reference counting for IAM-enabled Workload Identity mounts during NodeUnpublishVolume:
- Implements cleanUpIAMReference using glob matching and regex extraction to safely parse and decrement active pod references in /var/lib/lustre/mounts/<key>/refs/<pod-uid>.
- Safely unbind-mounts container target paths and automatically unmounts and purges the physical global mount point (mount/, token/, refs/) when the final pod detaches from the node.
- Adds comprehensive unit tests (TestNodeUnpublishVolume_IAM) verifying reference decrement and directory cleanup.

TAG=agy

Change-Id: Ida838b278a8afce278af251185f1872a2ffd48ac