### PR TITLE
Add lustre-csi-test AI agent skill for GKE testing

### DIFF
--- a/.agents/skills/lustre-csi-test/README.md
+++ b/.agents/skills/lustre-csi-test/README.md
@@ -60,4 +60,4 @@ When triggered, the agent will guide you through three interactive steps:
 2. **Builds & Pushes Staging Image:** Pauses for your approval, then builds and pushes a traceable staging image (`STAGINGVERSION=dev-<sha>-<timestamp>`).
 3. **Replaces Driver on GKE:** Uninstalls existing driver pods (`make uninstall`) and deploys your staging build (`make install`), monitoring `lustre-csi-node` (defined in `deploy/base/node/node.yaml` with init container `lustre-kmod-installer` and main container `lustre-csi-driver`).
 4. **Automated Deep Troubleshooting:** If any pod fails to start within **30 seconds**, the agent automatically inspects container logs (`lustre-kmod-installer` / `lustre-csi-driver`) and SSHes into the GKE node, running `lsmod | grep lustre` to verify kernel module loading before executing `dmesg`.
-5. **Verifies Active I/O:** Executes file write/read/delete tests inside the mounted Lustre volume and cleans up test workloads automatically.
+5. **Verifies Active I/O:** Executes file write/read/delete tests inside `/lustre_volume` on `lustre-pod` and cleans up test workloads automatically.

--- a/.agents/skills/lustre-csi-test/README.md
+++ b/.agents/skills/lustre-csi-test/README.md
@@ -1,0 +1,63 @@
+<!--
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Lustre CSI Driver Testing Skill (`lustre-csi-test`)
+
+`lustre-csi-test` is an AI agent skill that automates local verification suites, container builds, and live GKE integration testing (Static or Dynamic provisioning) for the **Lustre CSI Driver** on **Ubuntu** or **Container-Optimized OS (COS)** GKE nodes.
+
+---
+
+## Prerequisites
+
+Before invoking this skill, ensure you have the following installed and configured on your workstation:
+- **`gcloud` CLI:** Authenticated with permissions to access your GCP project, GKE cluster, and GCE instances.
+- **`kubectl`:** Installed and accessible in your `$PATH`.
+- **`make` & Docker/Buildx:** For building and pushing multi-arch container images.
+
+---
+
+## How to Use
+
+### 1. Invoking the Skill
+When working inside this repository, simply ask Antigravity to test your local changes:
+- *"Use `lustre-csi-test` to test my local changes on GKE with static provisioning."*
+- *"Run `lustre-csi-test` to build and test dynamic provisioning on my cluster."*
+
+---
+
+### 2. Interactive Setup Flow
+When triggered, the agent will guide you through three interactive steps:
+
+1. **GCP Project & Cluster Conflict Check:** Detects any mismatch between your active `gcloud` project and `kubectl` cluster context, asking explicitly which project to use (`gcloud config set project <PROJECT_NAME>`).
+2. **GKE Cluster:** Connects your local `kubectl` to your target GKE cluster (`gcloud container clusters get-credentials ...`) and inspects its VPC network.
+3. **Provisioning Mode:**
+   - **Static Provisioning (Fastest):** Uses an existing Lustre filesystem. You provide the full managed instance handle (`<project-id>/<instance-location>/<instance-name>`), IP, and filesystem name.
+     - **Same-VPC Enforcement:** Verifies that the existing Lustre instance and the GKE cluster belong to the exact same VPC network before proceeding.
+     - If you need the agent to list existing instances, it queries `gcloud alpha lustre instances list --location=-` and supports custom API endpoints via `CLOUDSDK_API_ENDPOINT_OVERRIDES_LUSTRE`:
+       - **Staging:** `https://staging-lustre.mtls.sandbox.googleapis.com/`
+       - **Autopush:** `https://autopush-lustre.mtls.sandbox.googleapis.com/`
+       - **Default:** Omit variable to use local environment default.
+   - **Dynamic Provisioning:** Tests dynamic volume creation via the `lustre-rwx` StorageClass.
+
+---
+
+### 3. What the Agent Does Automatically
+
+1. **Runs Local Suites First:** Executes `make unit-test`, `make sanity-test`, and `make verify`. If any fail, it self-corrects your code until all pass.
+2. **Builds & Pushes Staging Image:** Pauses for your approval, then builds and pushes a traceable staging image (`STAGINGVERSION=dev-<sha>-<timestamp>`).
+3. **Replaces Driver on GKE:** Uninstalls existing driver pods (`make uninstall`) and deploys your staging build (`make install`), monitoring `lustre-csi-node` (defined in `deploy/base/node/node.yaml` with init container `lustre-kmod-installer` and main container `lustre-csi-driver`).
+4. **Automated Deep Troubleshooting:** If any pod fails to start within **30 seconds**, the agent automatically inspects container logs (`lustre-kmod-installer` / `lustre-csi-driver`) and SSHes into the GKE node, running `lsmod | grep lustre` to verify kernel module loading before executing `dmesg`.
+5. **Verifies Active I/O:** Executes file write/read/delete tests inside the mounted Lustre volume and cleans up test workloads automatically.

--- a/.agents/skills/lustre-csi-test/SKILL.md
+++ b/.agents/skills/lustre-csi-test/SKILL.md
@@ -19,7 +19,7 @@ name: lustre-csi-test
 description: >-
   Guides local build, unit/sanity testing, and live GKE integration testing (static or dynamic provisioning)
   of the Lustre CSI Driver on Google Kubernetes Engine (GKE) nodes running Ubuntu or Container-Optimized OS (COS).
-  Use when testing local code changes or validating CSI driver builds on a GKE cluster.
+  Helps developers perform local validation, verify kernel module installation, test volume mounts, and execute simple I/O to ensure local changes conform to minimum quality standards.
 ---
 
 # Lustre CSI Driver Testing Workflow

--- a/.agents/skills/lustre-csi-test/SKILL.md
+++ b/.agents/skills/lustre-csi-test/SKILL.md
@@ -122,7 +122,7 @@ Uses `examples/pre-prov/preprov-pvc-pv.yaml` and `examples/pre-prov/preprov-pod.
        examples/pre-prov/preprov-pvc-pv.yaml | kubectl apply -f -
    kubectl apply -f examples/pre-prov/preprov-pod.yaml
    ```
-   - Expected Pod Name: `preprov-pod`
+   - Expected Pod Name: `lustre-pod`
 
 ### Mode B: Dynamic Provisioning Test
 Uses `examples/dynamic-prov/dynamic-pvc.yaml` and `examples/dynamic-prov/dynamic-pod.yaml`.
@@ -136,7 +136,7 @@ Uses `examples/dynamic-prov/dynamic-pvc.yaml` and `examples/dynamic-prov/dynamic
 ---
 
 ## Phase 4: 30-Second Pod Readiness & Deep Debugging Escalation
-1. Monitor the target test pod (`preprov-pod` for static, `lustre-pod` for dynamic).
+1. Monitor the target test pod (`lustre-pod`).
 2. **30-Second Timeout Rule:** If the pod does not reach `Running` within **30 seconds**, assume mounting failed:
    - First inspect CSI node driver logs:
      ```bash
@@ -148,12 +148,12 @@ Uses `examples/dynamic-prov/dynamic-pvc.yaml` and `examples/dynamic-prov/dynamic
 ---
 
 ## Phase 5: Active End-to-End I/O Verification & Clean Teardown
-1. Once the test pod enters `Running`, execute an interactive I/O check inside the pod (`preprov-pod` or `lustre-pod`):
+1. Once the test pod (`lustre-pod`) enters `Running`, execute an interactive I/O check inside the pod:
    ```bash
-   kubectl exec -it <pod-name> -- /bin/sh -c '
-     echo "lustre-test-data-$(date +%s)" > /mnt/lustre_volume/testfile && \
-     cat /mnt/lustre_volume/testfile && \
-     rm /mnt/lustre_volume/testfile
+   kubectl exec -it lustre-pod -- /bin/sh -c '
+     echo "lustre-test-data-$(date +%s)" > /lustre_volume/testfile && \
+     cat /lustre_volume/testfile && \
+     rm /lustre_volume/testfile
    '
    ```
    Confirm file write, read, and delete succeed without errors.

--- a/.agents/skills/lustre-csi-test/SKILL.md
+++ b/.agents/skills/lustre-csi-test/SKILL.md
@@ -1,0 +1,160 @@
+<!--
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+---
+name: lustre-csi-test
+description: >-
+  Guides local build, unit/sanity testing, and live GKE integration testing (static or dynamic provisioning)
+  of the Lustre CSI Driver on Google Kubernetes Engine (GKE) nodes running Ubuntu or Container-Optimized OS (COS).
+  Use when testing local code changes or validating CSI driver builds on a GKE cluster.
+---
+
+# Lustre CSI Driver Testing Workflow
+
+You are an expert Kubernetes and Storage engineer helping test local changes to the Lustre CSI Driver on Google Kubernetes Engine (GKE) nodes running **Ubuntu** or **Container-Optimized OS (COS)**.
+
+## Core Architecture & Debugging Rules
+### Split Architecture (Critical Knowledge)
+- **Host OS Support:** Nodes may run **Ubuntu** or **Container-Optimized OS (COS)**. The driver architecture is identical on both.
+- **Lustre Kernel Module (`kmod`):** Loaded on the host node (managed via `cos-dkms` or Secure Kernel Module Loading).
+- **Lustre Client Utilities (`lfs`, `lctl`, etc.):** **NOT installed on the host node.** They reside exclusively inside the CSI driver container image.
+- **Running Lustre Commands:** If you need to execute `lctl`, `lfs`, or other Lustre client tools for diagnostics, execute them inside the CSI node pod container:
+  ```bash
+  kubectl exec -it <lustre-csi-node-pod> -n lustre-csi-driver -c lustre-csi-driver -- /bin/sh
+  ```
+
+- **Lustre API Endpoint Overrides:** Managed Lustre supports non-prod API endpoints via `CLOUDSDK_API_ENDPOINT_OVERRIDES_LUSTRE`:
+  - **Staging:** `CLOUDSDK_API_ENDPOINT_OVERRIDES_LUSTRE=https://staging-lustre.mtls.sandbox.googleapis.com/`
+  - **Autopush:** `CLOUDSDK_API_ENDPOINT_OVERRIDES_LUSTRE=https://autopush-lustre.mtls.sandbox.googleapis.com/`
+  - **Default:** Omit variable to use local environment default.
+
+- **VPC Co-Location Requirement:** For Static Provisioning, the GKE cluster and the Managed Lustre instance MUST reside in the same VPC network. Otherwise, mounting will fail. Always verify matching networks before deploying test workloads.
+- **Node Kernel Module Verification:** Whenever SSHing into a host node (`gcloud compute ssh`), ALWAYS run `lsmod | grep lustre` first to verify whether the Lustre kernel module is loaded before inspecting kernel logs with `dmesg`.
+
+---
+
+## Phase 0: Interactive Environment Setup
+Before running any tests, explicitly prompt the user:
+1. **GCP Project & Cluster Conflict Check:**
+   - Check current project (`gcloud config get-value project`) and current `kubectl config current-context`.
+   - If there is any ambiguity or project mismatch between the local gcloud config and GKE cluster, explicitly ask: *"Which exact GCP project do you want to use?"* and run `gcloud config set project <PROJECT_NAME>`.
+2. **GKE Cluster Connection:** *"Which GKE cluster do you want to use? Please provide the cluster name, location, and project."*
+   - Connect via:
+     ```bash
+     gcloud container clusters get-credentials <cluster-name> --location <location> --project <project-name>
+     ```
+   - Record the cluster's VPC network (`gcloud container clusters describe <cluster-name> --location <location> --format='value(networkConfig.network)'`).
+3. **Provisioning Mode Selection:** *"Do you want to test with Static Provisioning using an existing Lustre instance (fastest), or Dynamic Provisioning?"*
+   - **If Static Provisioning:**
+     - Ask if the user already has the instance handle, IP, and filesystem name, OR if they want you to list existing instances using `gcloud alpha lustre instances list`.
+     - If listing existing instances, ask which API endpoint environment to use (**Staging**, **Autopush**, or **Default**) and query using:
+       ```bash
+       # Staging Example:
+       CLOUDSDK_API_ENDPOINT_OVERRIDES_LUSTRE=https://staging-lustre.mtls.sandbox.googleapis.com/ \
+         gcloud alpha lustre instances list --location=- --project=<PROJECT_NAME>
+       ```
+     - Record:
+       1. Full managed instance handle (`<project-id>/<instance-location>/<instance-name>`)
+       2. Lustre server IP address (`EXISTING_LUSTRE_IP_ADDRESS`)
+       3. Lustre filesystem name (`EXISTING_LUSTRE_FSNAME`)
+     - **MANDATORY SAME-VPC VERIFICATION:** Inspect the Lustre instance's network (`gcloud alpha lustre instances describe ... --format='value(network)'`). Confirm it matches the GKE cluster's VPC network. If they differ, STOP and inform the user immediately—mounting across separate VPCs without peering will fail.
+   - **If Dynamic Provisioning:** No existing instance details needed; the CSI driver will dynamically provision storage via `lustre-rwx` StorageClass.
+
+---
+
+## Phase 1: Local Validation & Image Build
+1. **Run Local Validation Suites:**
+   ```bash
+   make unit-test
+   make sanity-test
+   make verify
+   ```
+2. **Iterate:** Fix any build, lint, or test failures autonomously until all three commands pass cleanly.
+3. **CHECKPOINT — STOP AND WAIT:** Inform the user that local suites passed. Request permission to build and push the multi-arch staging image:
+   ```bash
+   STAGINGVERSION=dev-$(git rev-parse --short HEAD)-$(date +%m%d%H%M) make build-all-image-and-push-multi-arch
+   ```
+
+---
+
+## Phase 2: GKE Driver Replacement & Health Verification
+Only proceed after explicit user approval and successful image push.
+
+1. **Uninstall Existing Driver:**
+   ```bash
+   make uninstall
+   ```
+   Wait until all existing CSI driver resources terminate cleanly.
+2. **Install Built Driver:**
+   ```bash
+   STAGINGVERSION=<tag-from-phase-1> make install
+   ```
+3. **Verify DaemonSet & Deployment Status:** Check `kubectl get Deployment,DaemonSet,Pods -n lustre-csi-driver` until all CSI pods reach `Running`.
+4. **CSI Driver Failure Escalation Protocol:**
+   - If CSI driver pods do not enter `Running` state:
+     1. Check init container (`lustre-kmod-installer`) and main container (`lustre-csi-driver`) logs via `kubectl logs -n lustre-csi-driver <pod> -c <container>`. Note: `deploy/base/node/node.yaml` defines DaemonSet `lustre-csi-node` with init container `lustre-kmod-installer` and main container `lustre-csi-driver`.
+     2. If container logs do not explain the failure, SSH into the underlying GKE node (`gcloud compute ssh <node-name>`), run `lsmod | grep lustre` to check if the Lustre kernel module is loaded, and then run `dmesg` to inspect kernel module loading/LNet logs.
+
+---
+
+## Phase 3: Integration Testing (Static or Dynamic Provisioning)
+
+### Mode A: Static Provisioning Test (Fastest)
+Uses `examples/pre-prov/preprov-pvc-pv.yaml` and `examples/pre-prov/preprov-pod.yaml`.
+1. Substitute placeholders (`volumeHandle`, `ip`, `filesystem`) dynamically without modifying tracked git files:
+   ```bash
+   sed -e "s|<project-id>/<instance-location>/<instance-name>|$INSTANCE_HANDLE|g" \
+       -e "s|\${EXISTING_LUSTRE_IP_ADDRESS}|$LUSTRE_IP|g" \
+       -e "s|\${EXISTING_LUSTRE_FSNAME}|$FS_NAME|g" \
+       examples/pre-prov/preprov-pvc-pv.yaml | kubectl apply -f -
+   kubectl apply -f examples/pre-prov/preprov-pod.yaml
+   ```
+   - Expected Pod Name: `preprov-pod`
+
+### Mode B: Dynamic Provisioning Test
+Uses `examples/dynamic-prov/dynamic-pvc.yaml` and `examples/dynamic-prov/dynamic-pod.yaml`.
+1. Apply dynamic manifests directly:
+   ```bash
+   kubectl apply -f examples/dynamic-prov/dynamic-pvc.yaml
+   kubectl apply -f examples/dynamic-prov/dynamic-pod.yaml
+   ```
+   - Expected Pod Name: `lustre-pod`
+
+---
+
+## Phase 4: 30-Second Pod Readiness & Deep Debugging Escalation
+1. Monitor the target test pod (`preprov-pod` for static, `lustre-pod` for dynamic).
+2. **30-Second Timeout Rule:** If the pod does not reach `Running` within **30 seconds**, assume mounting failed:
+   - First inspect CSI node driver logs:
+     ```bash
+     kubectl logs -n lustre-csi-driver <node-pod> -c lustre-csi-driver
+     ```
+   - If CSI driver logs are insufficient, SSH into the GKE node (`gcloud compute ssh <node-name>`), run `lsmod | grep lustre` to verify if the Lustre kernel module is loaded, and then run `dmesg` to inspect kernel-level Lustre mount errors.
+   - If Lustre utility inspection (`lctl`, `lfs`) is needed, execute inside the CSI node driver container (`kubectl exec -it <node-pod> -n lustre-csi-driver -c lustre-csi-driver -- /bin/sh`).
+
+---
+
+## Phase 5: Active End-to-End I/O Verification & Clean Teardown
+1. Once the test pod enters `Running`, execute an interactive I/O check inside the pod (`preprov-pod` or `lustre-pod`):
+   ```bash
+   kubectl exec -it <pod-name> -- /bin/sh -c '
+     echo "lustre-test-data-$(date +%s)" > /mnt/lustre_volume/testfile && \
+     cat /mnt/lustre_volume/testfile && \
+     rm /mnt/lustre_volume/testfile
+   '
+   ```
+   Confirm file write, read, and delete succeed without errors.
+2. **Teardown:** Clean up test PV/PVC/Pod resources after verification so the cluster remains clean. Report test results to the user and remain active for further follow-up instructions.


### PR DESCRIPTION
Adds the `lustre-csi-test` AI agent skill to help developers perform local validation, verifying kernel module installation, PVC mount, and simple I/O to ensure local changes conform to minimum quality standards.