### PR TITLE
Using Lustre CreateInstanceOverride for smaller clients to prevent stockouts

### DIFF
--- a/test/k8s-integration/config/storage-class.yaml
+++ b/test/k8s-integration/config/storage-class.yaml
@@ -23,18 +23,13 @@ allowedTopologies:
   - matchLabelExpressions:
     - key: "topology.gke.io/zone"
       values:
+        # These zones are known to support 'CreateInstanceOverrides' lustre backend operation.
+        # We will add more zones that has `CreateInstanceOverrides` support overtime.
         - us-central1-a
-        - us-central1-b
         - us-central1-c
-        - us-central1-f
-        - us-east4-a
-        - us-east4-b
-        - us-east4-c
-        - us-east5-b
-        - us-south1-b
-        - us-west1-b
-        - us-west1-c
+        - us-west2-a
 parameters:
   network: lustre-network
   perUnitStorageThroughput: "1000"
   labels: "gke-testing-project=prow"
+  description: 'CreateInstanceOverrides={"CalculatorType": "C4_THIN"}'

--- a/test/k8s-integration/driver-config.go
+++ b/test/k8s-integration/driver-config.go
@@ -40,7 +40,7 @@ const (
 	configFile         = "test-config.yaml"
 
 	// configurable timeouts for the k8s e2e testsuites.
-	podStartTimeout       = "600s"
+	podStartTimeout       = "1800s"
 	claimProvisionTimeout = "3600s"
 	pvDeleteTimeout       = "3600s"
 
@@ -86,26 +86,14 @@ func generateDriverConfigFile(testParams *testParameters, storageClassFile strin
 		pvDeleteTimeoutKey:       pvDeleteTimeout,
 	}
 
-	minVolumeSize := "1Ti"
-	if testParams.gkeManagedDriver {
-		minSupportedVersion := "1.34.1"
-		clusterVer, err := parseVersion(testParams.clusterVersion)
-		if err != nil {
-			return "", err
-		}
-		ver, _ := parseVersion(minSupportedVersion)
-		if !clusterVer.lessThan(ver) {
-			minVolumeSize = "9000Gi"
-		} else {
-			minVolumeSize = "18000Gi"
-		}
-	}
+	// thinInstanceMinSize represents the size for thin client Lustre instances.
+	thinInstanceMinSize := "1024Gi"
 
 	params := driverConfig{
 		StorageClassFile:  filepath.Join(testParams.pkgDir, testConfigDir, storageClassFile),
 		StorageClass:      storageClassFile[:strings.LastIndex(storageClassFile, ".")],
 		Capabilities:      caps,
-		MinimumVolumeSize: minVolumeSize,
+		MinimumVolumeSize: thinInstanceMinSize,
 		Timeouts:          timeouts,
 	}
 

--- a/test/run-k8s-integration-local.sh
+++ b/test/run-k8s-integration-local.sh
@@ -26,5 +26,5 @@ multivolume_fs_test_focus="External.*Storage.*filesystem.*multiVolume"
 # E.g. run command: test/run-k8s-integration-local.sh | tee log
 "${PKGDIR}"/bin/k8s-integration-test --run-in-prow=false --pkg-dir="${PKGDIR}" \
 --bringup-cluster=true --test-focus="${all_external_tests_focus}" --do-network-setup=true \
---do-driver-build=true --gce-zone="us-central1-c" --use-gke-driver=false \
---num-nodes="${NUM_NODES:-1}" --multi-nic-num-nodes="${MULTI_NIC_NUM_NODES:-1}" --parallel=1 -test-version=1.32 --gke-cluster-version=1.32 --image-type="${IMAGE_TYPE:-cos_containerd}"
+--do-driver-build=true --gce-zone="us-central1-a" --use-gke-driver=false \
+--num-nodes="${NUM_NODES:-1}" --multi-nic-num-nodes="${MULTI_NIC_NUM_NODES:-1}" --parallel=1 --test-version=1.36 --gke-cluster-version=1.36 --image-type="${IMAGE_TYPE:-cos_containerd}"


### PR DESCRIPTION
We currently set us-central1-a as the selected storage-class zone since this (seems to be) the zone that works for CreateInstanceOverrides.

Local integration test run:
<img width="2818" height="1436" alt="image" src="https://github.com/user-attachments/assets/3e9c52d1-4db7-43a5-be3a-e420aaa256d2" />

