### PR TITLE
Remove us-west2-a due to PermissioDenied storageclass provision.

### DIFF
--- a/test/k8s-integration/config/storage-class.yaml
+++ b/test/k8s-integration/config/storage-class.yaml
@@ -27,7 +27,6 @@ allowedTopologies:
         # We will add more zones that has `CreateInstanceOverrides` support overtime.
         - us-central1-a
         - us-central1-c
-        - us-west2-a
 parameters:
   network: lustre-network
   perUnitStorageThroughput: "1000"


### PR DESCRIPTION
Remove us-west2-a and monitor testgrids. We are removing this zone due to permissiondenied on our integration tests.

<img width="3366" height="408" alt="image" src="https://github.com/user-attachments/assets/750b382e-fb37-41e1-bfb3-d8a812aab42b" />
