### PR TITLE
feat: add min-version and max-version flags for cos-dkms kmod installer

### DIFF
--- a/cmd/kmod_installer/main.go
+++ b/cmd/kmod_installer/main.go
@@ -32,6 +32,8 @@ var (
 	nodeID                 = flag.String("nodeid", "", "Node ID")
 	enableLegacyLustrePort = flag.Bool("enable-legacy-lustre-port", false, "If set to true, configure the legacy Lustre LNet port")
 	disableMultiNIC        = flag.Bool("disable-multi-nic", false, "If set to true, multi-NIC support is disabled and the driver will only use the default NIC (eth0)")
+	minVersion             = flag.String("min-version", "", "Minimum driver version for cos-dkms install")
+	maxVersion             = flag.String("max-version", "", "Maximum driver version for cos-dkms install")
 
 	// customModuleArgs contains custom module-args arguments for cos-dkms installation provided by user.
 	customModuleArgs stringSlice
@@ -115,7 +117,7 @@ func main() {
 
 	switch hostOS {
 	case "cos":
-		err = kmod.InstallLustreKmodOnCos(ctx, *enableLegacyLustrePort, customModuleArgs, nics, effectiveDisableMultiNIC, primaryNic)
+		err = kmod.InstallLustreKmodOnCos(ctx, *enableLegacyLustrePort, customModuleArgs, nics, effectiveDisableMultiNIC, primaryNic, *minVersion, *maxVersion)
 		if err != nil {
 			klog.Fatalf("Failed to install lustre kernel modules on COS: %v", err)
 		}

--- a/deploy/overlays/gke-release/node.yaml
+++ b/deploy/overlays/gke-release/node.yaml
@@ -64,6 +64,8 @@ spec:
             - --nodeid=$(KUBE_NODE_NAME)
             - --disable-multi-nic=false
             - --enable-legacy-lustre-port=false
+            # TODO: Update min-version to 2.16.0 and max-version to 2.16.9999 once IAM release is cut.
+            - --max-version=2.14.9999
           env:
             - name: KUBE_NODE_NAME
               valueFrom:

--- a/helm/lustre-csi-driver/templates/csi-node.yaml
+++ b/helm/lustre-csi-driver/templates/csi-node.yaml
@@ -52,6 +52,12 @@ spec:
           - --nodeid=$(KUBE_NODE_NAME)
           - --enable-legacy-lustre-port={{ .Values.image.kmod.enableLegacyLustrePort }}
           - --disable-multi-nic={{ .Values.image.kmod.disableMultiNic }}
+          {{- if .Values.image.kmod.minVersion }}
+          - --min-version={{ .Values.image.kmod.minVersion }}
+          {{- end }}
+          {{- if .Values.image.kmod.maxVersion }}
+          - --max-version={{ .Values.image.kmod.maxVersion }}
+          {{- end }}
         env:
           - name: KUBE_NODE_NAME
             valueFrom:

--- a/helm/lustre-csi-driver/values.yaml
+++ b/helm/lustre-csi-driver/values.yaml
@@ -28,6 +28,9 @@ image:
     pullPolicy: Always
     enableLegacyLustrePort: false
     disableMultiNic: false
+    # TODO: Update minVersion to "2.16.0" and maxVersion to "2.16.9999" once IAM release is cut.
+    minVersion: ""
+    maxVersion: "2.14.9999"
 
 sidecars:
   image:

--- a/pkg/kmod_installer/kmod_installer.go
+++ b/pkg/kmod_installer/kmod_installer.go
@@ -135,14 +135,9 @@ func readLnetConfig(path, defaultNic string) (string, error) {
 	return currNetworkNics, nil
 }
 
-// InstallLustreKmodOnCos installs the Lustre kernel modules on the node using cos-dkms on COS nodes.
-// It proceeds with the installation using the provided NICs.
-func InstallLustreKmodOnCos(ctx context.Context, enableLegacyPort bool, customModuleArgs []string, nics []string, disableMultiNIC bool, primaryNic string) error {
+// BuildCosDkmsArgs constructs the command-line arguments for cos-dkms install.
+func BuildCosDkmsArgs(enableLegacyPort bool, customModuleArgs []string, expectedNetwork string, minVersion string, maxVersion string) []string {
 	lnetPort := lnetPort(enableLegacyPort)
-	expectedNetwork := BuildLnetNetworkString(nics, primaryNic, disableMultiNIC)
-
-	cmdCtx, cancel := context.WithTimeout(ctx, cmdTimeout)
-	defer cancel()
 
 	// --gcs-bucket: Specifies the GCS bucket containing the driver packages ('cos-default').
 	// --latest: Installs the latest available driver version that is compatible with the kernel version running on the current node.
@@ -169,11 +164,31 @@ func InstallLustreKmodOnCos(ctx context.Context, enableLegacyPort bool, customMo
 		"--module-arg=lnet.accept_port="+strconv.Itoa(lnetPort),
 	)
 
+	if minVersion != "" {
+		args = append(args, "--min-version="+minVersion)
+	}
+	if maxVersion != "" {
+		args = append(args, "--max-version="+maxVersion)
+	}
+
 	args = append(args, fmt.Sprintf(`--module-arg=lnet.networks="%s"`, expectedNetwork))
 
 	for _, arg := range customModuleArgs {
 		args = append(args, "--module-arg="+arg)
 	}
+
+	return args
+}
+
+// InstallLustreKmodOnCos installs the Lustre kernel modules on the node using cos-dkms on COS nodes.
+// It proceeds with the installation using the provided NICs.
+func InstallLustreKmodOnCos(ctx context.Context, enableLegacyPort bool, customModuleArgs []string, nics []string, disableMultiNIC bool, primaryNic string, minVersion string, maxVersion string) error {
+	expectedNetwork := BuildLnetNetworkString(nics, primaryNic, disableMultiNIC)
+
+	cmdCtx, cancel := context.WithTimeout(ctx, cmdTimeout)
+	defer cancel()
+
+	args := BuildCosDkmsArgs(enableLegacyPort, customModuleArgs, expectedNetwork, minVersion, maxVersion)
 	cmd := exec.CommandContext(cmdCtx, "/usr/bin/cos-dkms", args...)
 	// TODO(samhalim): Add latency/success rate metrics for kmod cos-dkms install.
 

--- a/pkg/kmod_installer/kmod_installer_test.go
+++ b/pkg/kmod_installer/kmod_installer_test.go
@@ -354,3 +354,92 @@ func TestBuildLnetNetworkString(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildCosDkmsArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		enableLegacyPort bool
+		customModuleArgs []string
+		expectedNetwork  string
+		minVersion       string
+		maxVersion       string
+		want             []string
+	}{
+		{
+			name:             "default without min/max version",
+			enableLegacyPort: false,
+			customModuleArgs: nil,
+			expectedNetwork:  "tcp0(eth0)",
+			minVersion:       "",
+			maxVersion:       "",
+			want: []string{
+				"install", "lustre-client-drivers",
+				"--gcs-bucket=cos-default",
+				"--latest",
+				"-w", "0",
+				"--kernelmodulestree=/host_modules",
+				"--lsb-release-path=/host_etc/lsb-release",
+				"--insert-on-install",
+				"--logtostderr",
+				"--module-arg=lnet.accept_port=988",
+				`--module-arg=lnet.networks="tcp0(eth0)"`,
+			},
+		},
+		{
+			name:             "2.14 driver version constraint (max-version only)",
+			enableLegacyPort: false,
+			customModuleArgs: nil,
+			expectedNetwork:  "tcp0(eth0)",
+			minVersion:       "",
+			maxVersion:       "2.14.9999",
+			want: []string{
+				"install", "lustre-client-drivers",
+				"--gcs-bucket=cos-default",
+				"--latest",
+				"-w", "0",
+				"--kernelmodulestree=/host_modules",
+				"--lsb-release-path=/host_etc/lsb-release",
+				"--insert-on-install",
+				"--logtostderr",
+				"--module-arg=lnet.accept_port=988",
+				"--max-version=2.14.9999",
+				`--module-arg=lnet.networks="tcp0(eth0)"`,
+			},
+		},
+		{
+			name:             "2.16 driver version range (min-version and max-version for IAM)",
+			enableLegacyPort: false,
+			customModuleArgs: []string{"lnet.log_level=debug"},
+			expectedNetwork:  "tcp0(eth0,eth1)",
+			minVersion:       "2.16.0",
+			maxVersion:       "2.16.9999",
+			want: []string{
+				"install", "lustre-client-drivers",
+				"--gcs-bucket=cos-default",
+				"--latest",
+				"-w", "0",
+				"--kernelmodulestree=/host_modules",
+				"--lsb-release-path=/host_etc/lsb-release",
+				"--insert-on-install",
+				"--logtostderr",
+				"--module-arg=lnet.accept_port=988",
+				"--min-version=2.16.0",
+				"--max-version=2.16.9999",
+				`--module-arg=lnet.networks="tcp0(eth0,eth1)"`,
+				"--module-arg=lnet.log_level=debug",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := BuildCosDkmsArgs(tc.enableLegacyPort, tc.customModuleArgs, tc.expectedNetwork, tc.minVersion, tc.maxVersion)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("BuildCosDkmsArgs() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description
Adds support for `--min-version` and `--max-version` flags in the `kmod_installer` component when executing `cos-dkms install lustre-client-drivers`.

### Changes Included:
- **`pkg/kmod_installer`**: Extracted `BuildCosDkmsArgs` and added `minVersion` / `maxVersion` parameters to `InstallLustreKmodOnCos`.
- **`cmd/kmod_installer`**: Added CLI flags `--min-version` and `--max-version`.
- **Helm**: Updated `values.yaml` and `templates/csi-node.yaml` to configure `minVersion` / `maxVersion` under `image.kmod`.
- **Manifests**: Configured `--max-version=2.14.9999` with a TODO comment to update to 2.16 once the IAM release is cut.
- **Unit Tests**: Added `TestBuildCosDkmsArgs` test cases.

TAG=agy