### PR TITLE
fix(node): prevent unmount hangs and volumeLock deadlocks with cascading fallback

### DIFF
--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -67,6 +67,7 @@ type nodeServer struct {
 	driver      *LustreDriver
 	mounter     mount.Interface
 	volumeLocks *util.VolumeLocks
+	unmountExec unmountExecFunc
 }
 
 func newNodeServer(driver *LustreDriver, mounter mount.Interface) csi.NodeServer {
@@ -92,7 +93,7 @@ func (s *nodeServer) NodeGetCapabilities(_ context.Context, _ *csi.NodeGetCapabi
 	}, nil
 }
 
-func (s *nodeServer) NodeStageVolume(_ context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
+func (s *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID not provided")
@@ -194,8 +195,8 @@ func (s *nodeServer) NodeStageVolume(_ context.Context, req *csi.NodeStageVolume
 	klog.V(4).Infof("NodeStageVolume mounting volume %s to path %s on node %s with mountOptions %v", volumeID, target, nodeName, mountOptions)
 	if err := s.mounter.MountSensitiveWithoutSystemd(source, target, "lustre", mountOptions, nil); err != nil {
 		klog.Errorf("Mount %q failed on node %s, cleaning up", target, nodeName)
-		if unmntErr := mount.CleanupMountPoint(target, s.mounter, false /* extensiveMountPointCheck */); unmntErr != nil {
-			klog.Errorf("Unmount %q failed on node %s: %v", target, nodeName, unmntErr.Error())
+		if unmntErr := s.unmountPath(target); unmntErr != nil {
+			klog.Errorf("Unmount %q failed on node %s: %v", target, nodeName, unmntErr)
 		}
 
 		return nil, status.Errorf(codes.Internal, "Could not mount %q at %q on node %s: %v", source, target, nodeName, err)
@@ -206,7 +207,7 @@ func (s *nodeServer) NodeStageVolume(_ context.Context, req *csi.NodeStageVolume
 	return &csi.NodeStageVolumeResponse{}, nil
 }
 
-func (s *nodeServer) NodeUnstageVolume(_ context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
+func (s *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID not provided")
@@ -222,22 +223,9 @@ func (s *nodeServer) NodeUnstageVolume(_ context.Context, req *csi.NodeUnstageVo
 	}
 	defer s.volumeLocks.Release(target)
 
-	// Check if the target path is mounted before unmounting.
-	if notMnt, _ := s.mounter.IsLikelyNotMountPoint(target); notMnt {
-		klog.V(5).InfoS("NodeUnstageVolume: staging target path not mounted, skipping unmount", "staging target", target)
-
-		return &csi.NodeUnstageVolumeResponse{}, nil
-	}
-	// Always unmount the target path regardless of the detected mount state.
-	// In cases where Lustre was force-unmounted, CleanupMountPoint may fail
-	// to detect the state and error out with "cannot send after transport endpoint shutdown".
 	klog.V(5).InfoS("NodeUnstageVolume attempting to unmount", "staging target", target)
-	if err := s.mounter.Unmount(target); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to unmount staging target %q: %v", target, err)
-	}
-
-	if err := mount.CleanupMountPoint(target, s.mounter, false /* extensiveMountPointCheck */); err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+	if err := s.unmountPath(target); err != nil {
+		return nil, err
 	}
 
 	klog.V(4).Infof("NodeUnstageVolume succeeded on volume %v from staging target path %s on node %s", volumeID, target, s.driver.config.NodeID)
@@ -245,7 +233,7 @@ func (s *nodeServer) NodeUnstageVolume(_ context.Context, req *csi.NodeUnstageVo
 	return &csi.NodeUnstageVolumeResponse{}, nil
 }
 
-func (s *nodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID not provided")
@@ -316,7 +304,7 @@ func (s *nodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishVo
 	}
 
 	if isIAM {
-		if err := s.publishIAMVolume(volumeID, targetPath, targetMounted, vc, mountOptions, volCap); err != nil {
+		if err := s.publishIAMVolume(ctx, volumeID, targetPath, targetMounted, vc, mountOptions, volCap); err != nil {
 			return nil, err
 		}
 	} else if !targetMounted {
@@ -329,8 +317,8 @@ func (s *nodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishVo
 
 	if err := setVolumeOwnershipTopLevel(volumeID, targetPath, fsGroup, ro); err != nil {
 		klog.V(5).Infof("setVolumeOwnershipTopLevel failed for volume %q, path %q, fsGroup %q, cleaning up mount point on node %s", volumeID, targetPath, fsGroup, nodeName)
-		if unmntErr := mount.CleanupMountPoint(targetPath, s.mounter, false /* extensiveMountPointCheck */); unmntErr != nil {
-			klog.Errorf("Unmount %q failed on node %s: %v", targetPath, nodeName, unmntErr.Error())
+		if unmntErr := s.unmountPath(targetPath); unmntErr != nil {
+			klog.Errorf("Unmount %q failed on node %s: %v", targetPath, nodeName, unmntErr)
 		}
 
 		return nil, status.Error(codes.Internal, err.Error())
@@ -341,7 +329,7 @@ func (s *nodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishVo
 
 // publishIAMVolume manages the global mount, token lifecycle, reference counting,
 // and bind mounting for IAM-enabled volumes.
-func (s *nodeServer) publishIAMVolume(volumeID, targetPath string, targetMounted bool, vc map[string]string, mountOptions []string, volCap *csi.VolumeCapability) error {
+func (s *nodeServer) publishIAMVolume(ctx context.Context, volumeID, targetPath string, targetMounted bool, vc map[string]string, mountOptions []string, volCap *csi.VolumeCapability) error {
 	podUID := vc[normalize(keyPodUID)]
 	namespace := vc[normalize(keyPodNamespace)]
 	saName := vc[normalize(keyServiceAccount)]
@@ -401,7 +389,7 @@ func (s *nodeServer) publishIAMVolume(volumeID, targetPath string, targetMounted
 	}
 
 	if !globalMounted {
-		if err := s.mountGlobalIAM(volumeID, globalMountPath, principal, key, vc, volCap); err != nil {
+		if err := s.mountGlobalIAM(ctx, volumeID, globalMountPath, principal, key, vc, volCap); err != nil {
 			return err
 		}
 	}
@@ -418,7 +406,7 @@ func (s *nodeServer) publishIAMVolume(volumeID, targetPath string, targetMounted
 			if err := removePodReference(key, podUID); err != nil {
 				klog.Errorf("Failed to clean up pod reference for pod %s, volume %s: %v", podUID, volumeID, err)
 			}
-			if unmntErr := mount.CleanupMountPoint(targetPath, s.mounter, false /* extensiveMountPointCheck */); unmntErr != nil {
+			if unmntErr := s.unmountPath(targetPath); unmntErr != nil {
 				klog.Errorf("Failed to clean up target mount point %q: %v", targetPath, unmntErr)
 			}
 			return status.Errorf(codes.Internal, "Bind mount failed for volume %q to target path %q: %v", volumeID, targetPath, err)
@@ -430,7 +418,7 @@ func (s *nodeServer) publishIAMVolume(volumeID, targetPath string, targetMounted
 
 // mountGlobalIAM parses target storage endpoints, configures multi-NIC routing,
 // and mounts the Lustre instance to the per-principal global mount path.
-func (s *nodeServer) mountGlobalIAM(volumeID, globalMountPath, principal, key string, vc map[string]string, volCap *csi.VolumeCapability) error {
+func (s *nodeServer) mountGlobalIAM(ctx context.Context, volumeID, globalMountPath, principal, key string, vc map[string]string, volCap *csi.VolumeCapability) error {
 	ip := vc[normalize(keyInstanceIP)]
 	fsname := vc[normalize(keyFilesystem)]
 	mountPoint := vc[normalize(keyMountPoint)]
@@ -474,8 +462,8 @@ func (s *nodeServer) mountGlobalIAM(volumeID, globalMountPath, principal, key st
 	klog.V(5).Infof("mountGlobalIAM mounting volume %s to path %s on node %s with mountOptions %v", volumeID, globalMountPath, nodeName, iamMountOptions)
 	if err := s.mounter.MountSensitiveWithoutSystemd(source, globalMountPath, "lustre", iamMountOptions, nil); err != nil {
 		klog.Errorf("Mount %q failed on node %s for principal %s, cleaning up", globalMountPath, nodeName, principal)
-		if unmntErr := mount.CleanupMountPoint(globalMountPath, s.mounter, false /* extensiveMountPointCheck */); unmntErr != nil {
-			klog.Errorf("Unmount %q failed on node %s for principal %s: %v", globalMountPath, nodeName, principal, unmntErr.Error())
+		if unmntErr := s.unmountPath(globalMountPath); unmntErr != nil {
+			klog.Errorf("Unmount %q failed on node %s for principal %s: %v", globalMountPath, nodeName, principal, unmntErr)
 		}
 
 		return status.Errorf(codes.Internal, "Could not mount %q at %q on node %s: %v", source, globalMountPath, nodeName, err)
@@ -486,7 +474,7 @@ func (s *nodeServer) mountGlobalIAM(volumeID, globalMountPath, principal, key st
 	return nil
 }
 
-func (s *nodeServer) NodeUnpublishVolume(_ context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+func (s *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
 	// Validate arguments.
 	targetPath := req.GetTargetPath()
 	if len(targetPath) == 0 {
@@ -499,22 +487,9 @@ func (s *nodeServer) NodeUnpublishVolume(_ context.Context, req *csi.NodeUnpubli
 	}
 	defer s.volumeLocks.Release(targetPath)
 
-	// Check if the target path is mounted before unmounting.
-	if notMnt, _ := s.mounter.IsLikelyNotMountPoint(targetPath); notMnt {
-		klog.V(5).InfoS("NodeUnpublishVolume: target path not mounted, skipping unmount", "target", targetPath)
-
-		return &csi.NodeUnpublishVolumeResponse{}, nil
-	}
-	// Always unmount the target path regardless of the detected mount state.
-	// In cases where Lustre was force-unmounted, CleanupMountPoint may fail
-	// to detect the state and error out with "cannot send after transport endpoint shutdown".
 	klog.V(5).InfoS("NodeUnpublishVolume attempting to unmount", "target", targetPath)
-	if err := s.mounter.Unmount(targetPath); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to unmount target %q: %v", targetPath, err)
-	}
-
-	if err := mount.CleanupMountPoint(targetPath, s.mounter, false /* extensiveMountPointCheck */); err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+	if err := s.unmountPath(targetPath); err != nil {
+		return nil, err
 	}
 
 	if err := s.cleanUpIAMReference(targetPath); err != nil {
@@ -937,17 +912,8 @@ func (s *nodeServer) cleanUpIAMReferenceForKey(key, refPath string) error {
 	klog.Infof("No more pod references for key %s. Unmounting global path.", key)
 	globalMountPath := filepath.Join(GlobalMountRoot, key, "mount")
 
-	if notMnt, _ := s.mounter.IsLikelyNotMountPoint(globalMountPath); !notMnt {
-		// Manual unmount to clear transport-shutdown or corrupted states.
-		klog.V(4).Infof("Performing explicit unmount of global path %q", globalMountPath)
-		if err := s.mounter.Unmount(globalMountPath); err != nil {
-			return fmt.Errorf("failed robust unmount of global path %q: %w", globalMountPath, err)
-		}
-	}
-
-	// Cleanup to verify unmount and remove the 'mount' directory.
-	if err := mount.CleanupMountPoint(globalMountPath, s.mounter, false /* extensiveMountPointCheck */); err != nil {
-		return fmt.Errorf("failed standard cleanup for global mount point %q: %w", globalMountPath, err)
+	if err := s.unmountPath(globalMountPath); err != nil {
+		return fmt.Errorf("failed to unmount global path %q: %w", globalMountPath, err)
 	}
 
 	// Clean up the entire key folder

--- a/pkg/csi_driver/node_test.go
+++ b/pkg/csi_driver/node_test.go
@@ -1284,7 +1284,7 @@ func TestPublishIAMVolume(t *testing.T) {
 				normalizedVC[normalize(k)] = v
 			}
 
-			err := ns.publishIAMVolume(testVolumeID, testTargetPath, tc.targetMounted, normalizedVC, []string{"bind"}, testVolumeCapability)
+			err := ns.publishIAMVolume(t.Context(), testVolumeID, testTargetPath, tc.targetMounted, normalizedVC, []string{"bind"}, testVolumeCapability)
 			if (err != nil) != tc.expectErr {
 				t.Fatalf("Test %q: expected error %v, got %v", tc.name, tc.expectErr, err)
 			}
@@ -1515,7 +1515,7 @@ func TestMountGlobalIAM(t *testing.T) {
 
 			ns := newNodeServer(driver, mounter).(*nodeServer)
 
-			err := ns.mountGlobalIAM(testVolumeID, testGlobalMountPath, testPrincipal, testKey, tc.vc, tc.volCap)
+			err := ns.mountGlobalIAM(t.Context(), testVolumeID, testGlobalMountPath, testPrincipal, testKey, tc.vc, tc.volCap)
 			if tc.expectErr && err == nil {
 				t.Fatalf("Test %q: expected an error but got none", tc.name)
 			}

--- a/pkg/csi_driver/unmount.go
+++ b/pkg/csi_driver/unmount.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/klog/v2"
+	mount "k8s.io/mount-utils"
+)
+
+const (
+	// DefaultUnmountTimeout is the maximum duration to wait for a standard umount.
+	DefaultUnmountTimeout = 15 * time.Second
+	// DefaultForceUnmountTimeout is the maximum duration to wait for a force umount (-f).
+	DefaultForceUnmountTimeout = 10 * time.Second
+	// DefaultLazyUnmountTimeout is the maximum duration to wait for a lazy umount (-l).
+	DefaultLazyUnmountTimeout = 5 * time.Second
+
+	errNotMounted = "not mounted"
+)
+
+type unmountExecFunc func(ctx context.Context, args ...string) ([]byte, error)
+
+// execUmount executes umount with given arguments and context without blocking on D-state tasks.
+func (s *nodeServer) execUmount(ctx context.Context, args ...string) ([]byte, error) {
+	if s.unmountExec != nil {
+		return s.unmountExec(ctx, args...)
+	}
+
+	// In test environments using FakeMounter, delegate to FakeMounter.Unmount if no custom unmountExec is set.
+	if fm := extractFakeMounter(s.mounter); fm != nil {
+		var target string
+		if len(args) > 0 {
+			target = args[len(args)-1]
+		}
+		err := fm.Unmount(target)
+		return nil, err
+	}
+
+	cmd := exec.Command("umount", args...)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	select {
+	case err := <-done:
+		return buf.Bytes(), err
+	case <-ctx.Done():
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		return nil, ctx.Err()
+	}
+}
+
+// unmountPath unmounts the target path using a cascading fallback strategy:
+// 1. Standard umount (DefaultUnmountTimeout = 15s)
+// 2. Force umount -f (DefaultForceUnmountTimeout = 10s) if standard umount times out or fails
+// 3. Lazy umount -l (DefaultLazyUnmountTimeout = 5s) if force umount times out or fails
+// After successfully detaching the mount, the directory is deleted.
+//
+// NOTE on Context Handling:
+// unmountPath intentionally does NOT accept or derive from the caller's gRPC context.
+// Instead, it manages its own internal timeouts using context.Background().
+// Rationale: If a caller's request context was cancelled or timed out (e.g. Kubelet 2-minute deadline
+// or client disconnect), deriving from that cancelled context would cause all three unmount phases
+// to abort immediately without actually executing umount -f or umount -l.
+// Because unmounting is a critical cleanup operation, it must run to completion to prevent leaked
+// mount points and wedged kernel/lock states. The total execution time is strictly bounded by
+// DefaultUnmountTimeout + DefaultForceUnmountTimeout + DefaultLazyUnmountTimeout (<= 30s), which is
+// well within Kubelet's retry timeout.
+func (s *nodeServer) unmountPath(target string) error {
+	notMnt, err := s.mounter.IsLikelyNotMountPoint(target)
+	if err != nil && !os.IsNotExist(err) {
+		if isCorruptedMnt(err) {
+			klog.V(4).Infof("unmountPath: target %q is corrupted mount, proceeding with unmount", target)
+		} else {
+			klog.Warningf("unmountPath: error checking if %q is a mount point: %v, proceeding with unmount", target, err)
+		}
+		notMnt = false
+	}
+
+	if notMnt {
+		klog.V(5).Infof("unmountPath: target path %s is not mounted, removing directory", target)
+		return removeDir(target)
+	}
+
+	// Phase 1: Standard unmount with bounded timeout
+	klog.V(4).Infof("unmountPath: attempting standard unmount on %s", target)
+	ctxStandard, cancelStandard := context.WithTimeout(context.Background(), DefaultUnmountTimeout)
+	out, err := s.execUmount(ctxStandard, target)
+	cancelStandard()
+
+	if err == nil || isNotMounted(err, out) {
+		klog.V(4).Infof("unmountPath: standard unmount succeeded on %s", target)
+		return removeDir(target)
+	}
+
+	// Phase 2: Force unmount (-f) with bounded timeout
+	klog.Warningf("unmountPath: standard unmount failed or timed out on %s (err: %v, out: %s). Attempting force unmount (umount -f)...", target, err, string(out))
+	ctxForce, cancelForce := context.WithTimeout(context.Background(), DefaultForceUnmountTimeout)
+	out, err = s.execUmount(ctxForce, "-f", target)
+	cancelForce()
+
+	if err == nil || isNotMounted(err, out) {
+		klog.V(4).Infof("unmountPath: force unmount succeeded on %s", target)
+		return removeDir(target)
+	}
+
+	// Phase 3: Lazy unmount (-l / MNT_DETACH) as ultimate fallback to avoid wedging the node
+	klog.Warningf("unmountPath: force unmount failed or timed out on %s (err: %v, out: %s). Falling back to lazy unmount (umount -l)...", target, err, string(out))
+	ctxLazy, cancelLazy := context.WithTimeout(context.Background(), DefaultLazyUnmountTimeout)
+	out, err = s.execUmount(ctxLazy, "-l", target)
+	cancelLazy()
+
+	if err == nil || isNotMounted(err, out) {
+		klog.V(4).Infof("unmountPath: lazy unmount succeeded on %s", target)
+		return removeDir(target)
+	}
+
+	return status.Errorf(codes.Internal, "failed to unmount target %q after standard, force, and lazy attempts: %v (output: %s)", target, err, string(out))
+}
+
+func isNotMounted(err error, output []byte) bool {
+	if err != nil && strings.Contains(strings.ToLower(err.Error()), errNotMounted) {
+		return true
+	}
+	if strings.Contains(strings.ToLower(string(output)), errNotMounted) {
+		return true
+	}
+	return false
+}
+
+func extractFakeMounter(m mount.Interface) *mount.FakeMounter {
+	if m == nil {
+		return nil
+	}
+	if fm, ok := m.(*mount.FakeMounter); ok {
+		return fm
+	}
+	// Check if the mounter embeds *mount.FakeMounter (e.g. fakeMounter in tests)
+	val := reflect.ValueOf(m)
+	if val.Kind() == reflect.Ptr && !val.IsNil() {
+		val = val.Elem()
+	}
+	if val.Kind() == reflect.Struct {
+		field := val.FieldByName("FakeMounter")
+		if field.IsValid() {
+			if fm, ok := field.Interface().(*mount.FakeMounter); ok {
+				return fm
+			}
+		}
+	}
+	return nil
+}
+
+func removeDir(target string) error {
+	if err := os.Remove(target); err != nil && !os.IsNotExist(err) {
+		return status.Errorf(codes.Internal, "failed to remove mount directory %q: %v", target, err)
+	}
+	return nil
+}

--- a/pkg/csi_driver/unmount_test.go
+++ b/pkg/csi_driver/unmount_test.go
@@ -1,0 +1,270 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	csi "github.com/container-storage-interface/spec/lib/go/csi"
+	mount "k8s.io/mount-utils"
+)
+
+func TestUnmountPath_CascadingFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		mounts        []mount.MountPoint
+		execResponses map[string]struct {
+			out []byte
+			err error
+		}
+		expectedCalls    []string
+		expectErr        bool
+		dirExistsBefore  bool
+		expectDirRemoved bool
+	}{
+		{
+			name: "Standard unmount succeeds on first attempt",
+			mounts: []mount.MountPoint{
+				{Device: testDevice, Path: "/test/staging"},
+			},
+			execResponses: map[string]struct {
+				out []byte
+				err error
+			}{
+				"umount /test/staging": {out: nil, err: nil},
+			},
+			expectedCalls:    []string{"umount /test/staging"},
+			expectErr:        false,
+			dirExistsBefore:  true,
+			expectDirRemoved: true,
+		},
+		{
+			name: "Standard unmount fails, force unmount (-f) succeeds",
+			mounts: []mount.MountPoint{
+				{Device: testDevice, Path: "/test/staging"},
+			},
+			execResponses: map[string]struct {
+				out []byte
+				err error
+			}{
+				"umount /test/staging":    {out: []byte("device busy"), err: errors.New("exit status 32")},
+				"umount -f /test/staging": {out: nil, err: nil},
+			},
+			expectedCalls: []string{
+				"umount /test/staging",
+				"umount -f /test/staging",
+			},
+			expectErr:        false,
+			dirExistsBefore:  true,
+			expectDirRemoved: true,
+		},
+		{
+			name: "Standard and force unmount fail, lazy unmount (-l) succeeds",
+			mounts: []mount.MountPoint{
+				{Device: testDevice, Path: "/test/staging"},
+			},
+			execResponses: map[string]struct {
+				out []byte
+				err error
+			}{
+				"umount /test/staging":    {out: []byte("target is busy"), err: errors.New("exit status 32")},
+				"umount -f /test/staging": {out: []byte("operation not supported"), err: errors.New("exit status 1")},
+				"umount -l /test/staging": {out: nil, err: nil},
+			},
+			expectedCalls: []string{
+				"umount /test/staging",
+				"umount -f /test/staging",
+				"umount -l /test/staging",
+			},
+			expectErr:        false,
+			dirExistsBefore:  true,
+			expectDirRemoved: true,
+		},
+		{
+			name: "All unmount attempts fail, returns error",
+			mounts: []mount.MountPoint{
+				{Device: testDevice, Path: "/test/staging"},
+			},
+			execResponses: map[string]struct {
+				out []byte
+				err error
+			}{
+				"umount /test/staging":    {out: []byte("error 1"), err: errors.New("exit status 1")},
+				"umount -f /test/staging": {out: []byte("error 2"), err: errors.New("exit status 2")},
+				"umount -l /test/staging": {out: []byte("fatal error"), err: errors.New("exit status 3")},
+			},
+			expectedCalls: []string{
+				"umount /test/staging",
+				"umount -f /test/staging",
+				"umount -l /test/staging",
+			},
+			expectErr:        true,
+			dirExistsBefore:  true,
+			expectDirRemoved: false,
+		},
+		{
+			name:   "Path is not a mount point, cleans up directory directly",
+			mounts: []mount.MountPoint{},
+			execResponses: map[string]struct {
+				out []byte
+				err error
+			}{},
+			expectedCalls:    nil,
+			expectErr:        false,
+			dirExistsBefore:  true,
+			expectDirRemoved: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			targetPath := filepath.Join(tmpDir, "staging")
+
+			if tc.dirExistsBefore {
+				if err := os.MkdirAll(targetPath, 0750); err != nil {
+					t.Fatalf("Failed to create test directory: %v", err)
+				}
+			}
+
+			// Adjust mount paths to match targetPath
+			var mountPoints []mount.MountPoint
+			for _, m := range tc.mounts {
+				mountPoints = append(mountPoints, mount.MountPoint{
+					Device: m.Device,
+					Path:   targetPath,
+				})
+			}
+
+			fm := &mount.FakeMounter{MountPoints: mountPoints}
+			testEnv := initTestNodeServer(t)
+			ns := testEnv.ns.(*nodeServer)
+			ns.mounter = fm
+
+			var mu sync.Mutex
+			var recordedCalls []string
+
+			ns.unmountExec = func(ctx context.Context, args ...string) ([]byte, error) {
+				mu.Lock()
+				defer mu.Unlock()
+
+				callKey := "umount"
+				for _, arg := range args {
+					if arg == targetPath {
+						callKey += " /test/staging"
+					} else {
+						callKey += " " + arg
+					}
+				}
+				recordedCalls = append(recordedCalls, callKey)
+
+				resp, exists := tc.execResponses[callKey]
+				if !exists {
+					return nil, errors.New("unexpected command call: " + callKey)
+				}
+				return resp.out, resp.err
+			}
+
+			err := ns.unmountPath(targetPath)
+			if (err != nil) != tc.expectErr {
+				t.Fatalf("unmountPath() error = %v, expectErr = %v", err, tc.expectErr)
+			}
+
+			mu.Lock()
+			if len(recordedCalls) != len(tc.expectedCalls) {
+				t.Errorf("Recorded calls = %v, expected = %v", recordedCalls, tc.expectedCalls)
+			} else {
+				for i := range recordedCalls {
+					if recordedCalls[i] != tc.expectedCalls[i] {
+						t.Errorf("Call %d = %q, expected %q", i, recordedCalls[i], tc.expectedCalls[i])
+					}
+				}
+			}
+			mu.Unlock()
+
+			_, statErr := os.Stat(targetPath)
+			dirExists := !os.IsNotExist(statErr)
+			if tc.expectDirRemoved && dirExists {
+				t.Errorf("Expected directory %s to be removed, but it still exists", targetPath)
+			}
+			if !tc.expectDirRemoved && tc.dirExistsBefore && !dirExists {
+				t.Errorf("Expected directory %s to remain, but it was removed", targetPath)
+			}
+		})
+	}
+}
+
+func TestUnmountPath_ContextTimeoutAndLockRelease(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	targetPath := filepath.Join(tmpDir, "staging")
+	if err := os.MkdirAll(targetPath, 0750); err != nil {
+		t.Fatalf("Failed to create test directory: %v", err)
+	}
+
+	fm := &mount.FakeMounter{
+		MountPoints: []mount.MountPoint{
+			{Device: testDevice, Path: targetPath},
+		},
+	}
+	testEnv := initTestNodeServer(t)
+	ns := testEnv.ns.(*nodeServer)
+	ns.mounter = fm
+
+	// Simulate hanging commands that simulate timeout / deadline exceeded
+	ns.unmountExec = func(ctx context.Context, args ...string) ([]byte, error) {
+		return nil, context.DeadlineExceeded
+	}
+
+	req := &csi.NodeUnstageVolumeRequest{
+		VolumeId:          testVolumeID,
+		StagingTargetPath: targetPath,
+	}
+
+	start := time.Now()
+	_, err := ns.NodeUnstageVolume(context.Background(), req)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("Expected NodeUnstageVolume to fail due to timeout, got success")
+	}
+
+	// Verify that the call returned promptly without blocking forever
+	if elapsed > 2*time.Second {
+		t.Errorf("NodeUnstageVolume took %v, expected return within ~1s", elapsed)
+	}
+
+	// CRITICAL TEST: Verify that the volume lock was released so that a subsequent call can acquire it
+	acquired := ns.volumeLocks.TryAcquire(targetPath)
+	if !acquired {
+		t.Errorf("Volume lock for %s was not released after NodeUnstageVolume failure!", targetPath)
+	} else {
+		ns.volumeLocks.Release(targetPath)
+	}
+}


### PR DESCRIPTION
### Problem Statement
During pod teardown or volume unstage/unpublish operations (`NodeUnstageVolume`, `NodeUnpublishVolume`), if the Lustre filesystem is experiencing network partitions, dropped RPCs, or unresponsive backend targets (MDS/OSTs), the synchronous `sys_umount` syscall (`ll_put_super`) blocks in uninterruptible kernel sleep (`TASK_UNINTERRUPTIBLE` / `D` state) while attempting to flush dirty pages (`cl_sync_io_wait`), cancel locks (`ldlm_cli_cancel`), or send disconnect RPCs (`obd_disconnect`).

Because `s.mounter.Unmount(target)` internally executed `exec.Command("umount", target)` without a timeout or context deadline:
1. The gRPC handler goroutine blocked indefinitely inside the kernel syscall.
2. `defer s.volumeLocks.Release(target)` was never reached.
3. Kubelet timed out the gRPC call after 2 minutes and retried, but every subsequent retry immediately failed with `codes.Aborted: An operation with the given volume key <target> already exists`.
4. The volume and node remained permanently wedged until the CSI driver pod was manually restarted.

---

### Design & Solution Reasoning

#### 1. Three-Tier Cascading Unmount Fallback (`pkg/csi_driver/unmount.go`)
We introduce `unmountPath(target)` which applies a bounded, cascading fallback strategy:
- **Phase 1 (Standard Unmount)**: Runs `umount <target>` with a 15-second bounded timeout (`DefaultUnmountTimeout`).
- **Phase 2 (Force Unmount)**: If Phase 1 times out or fails with an error, escalates to `umount -f <target>` with a 10-second bounded timeout (`DefaultForceUnmountTimeout`).
- **Phase 3 (Lazy Unmount / `MNT_DETACH`)**: If Phase 2 also times out or fails, falls back to `umount -l <target>` with a 5-second bounded timeout (`DefaultLazyUnmountTimeout`).
- **Directory Cleanup**: Once detached from the VFS namespace, the staging/target directory is removed.

> **Why `umount -l` (Lazy Unmount) is necessary**:
> When a Lustre MDS or OST is completely unreachable or deadlocked in kernel space, even `umount -f` can fail with transport errors or block. Lazy unmount (`MNT_DETACH`) detaches the mount point from the VFS namespace immediately. This enables Kubelet to clean up the mount directory and finalize volume teardown, while the Linux kernel finishes releasing Lustre resources asynchronously in the background once communication recovers.

#### 2. Non-blocking Execution Against Kernel D-State Hangs
- In Linux, when a process enters uninterruptible kernel sleep (`D` state), standard `exec.CommandContext` / `cmd.Wait()` blocks inside the `wait4` syscall because the kernel cannot return until the process wakes up from D-state.
- `execUmount` runs `cmd.Wait()` in a background goroutine and selects on `<-done` vs `<-ctx.Done()`. When timeout triggers, `SIGKILL` is sent and the CSI driver goroutine returns immediately without blocking.

#### 3. Independent Cleanup Contexts
- `unmountPath` manages its internal timeouts using `context.Background()`. If a parent request context was cancelled or timed out by Kubelet, `unmountPath` will still run its cascading fallback to completion rather than immediately aborting, ensuring clean volume detachment and node lock release.

#### 4. Guaranteed Lock Release
- The total worst-case unmount duration across all 3 phases is strictly bounded to $\le 30$ seconds (well below Kubelet's 120s RPC timeout).
- Every code path is guaranteed to return, ensuring `defer s.volumeLocks.Release(target)` always executes and freeing the volume lock for future attempts.