### PR TITLE
Backport non-IAM stability and bugfix commits to release-0.6

### DIFF
--- a/.agents/skills/lustre-csi-test/README.md
+++ b/.agents/skills/lustre-csi-test/README.md
@@ -60,4 +60,4 @@ When triggered, the agent will guide you through three interactive steps:
 2. **Builds & Pushes Staging Image:** Pauses for your approval, then builds and pushes a traceable staging image (`STAGINGVERSION=dev-<sha>-<timestamp>`).
 3. **Replaces Driver on GKE:** Uninstalls existing driver pods (`make uninstall`) and deploys your staging build (`make install`), monitoring `lustre-csi-node` (defined in `deploy/base/node/node.yaml` with init container `lustre-kmod-installer` and main container `lustre-csi-driver`).
 4. **Automated Deep Troubleshooting:** If any pod fails to start within **30 seconds**, the agent automatically inspects container logs (`lustre-kmod-installer` / `lustre-csi-driver`) and SSHes into the GKE node, running `lsmod | grep lustre` to verify kernel module loading before executing `dmesg`.
-5. **Verifies Active I/O:** Executes file write/read/delete tests inside the mounted Lustre volume and cleans up test workloads automatically.
+5. **Verifies Active I/O:** Executes file write/read/delete tests inside `/lustre_volume` on `lustre-pod` and cleans up test workloads automatically.

--- a/.agents/skills/lustre-csi-test/README.md
+++ b/.agents/skills/lustre-csi-test/README.md
@@ -1,0 +1,63 @@
+<!--
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Lustre CSI Driver Testing Skill (`lustre-csi-test`)
+
+`lustre-csi-test` is an AI agent skill that automates local verification suites, container builds, and live GKE integration testing (Static or Dynamic provisioning) for the **Lustre CSI Driver** on **Ubuntu** or **Container-Optimized OS (COS)** GKE nodes.
+
+---
+
+## Prerequisites
+
+Before invoking this skill, ensure you have the following installed and configured on your workstation:
+- **`gcloud` CLI:** Authenticated with permissions to access your GCP project, GKE cluster, and GCE instances.
+- **`kubectl`:** Installed and accessible in your `$PATH`.
+- **`make` & Docker/Buildx:** For building and pushing multi-arch container images.
+
+---
+
+## How to Use
+
+### 1. Invoking the Skill
+When working inside this repository, simply ask Antigravity to test your local changes:
+- *"Use `lustre-csi-test` to test my local changes on GKE with static provisioning."*
+- *"Run `lustre-csi-test` to build and test dynamic provisioning on my cluster."*
+
+---
+
+### 2. Interactive Setup Flow
+When triggered, the agent will guide you through three interactive steps:
+
+1. **GCP Project & Cluster Conflict Check:** Detects any mismatch between your active `gcloud` project and `kubectl` cluster context, asking explicitly which project to use (`gcloud config set project <PROJECT_NAME>`).
+2. **GKE Cluster:** Connects your local `kubectl` to your target GKE cluster (`gcloud container clusters get-credentials ...`) and inspects its VPC network.
+3. **Provisioning Mode:**
+   - **Static Provisioning (Fastest):** Uses an existing Lustre filesystem. You provide the full managed instance handle (`<project-id>/<instance-location>/<instance-name>`), IP, and filesystem name.
+     - **Same-VPC Enforcement:** Verifies that the existing Lustre instance and the GKE cluster belong to the exact same VPC network before proceeding.
+     - If you need the agent to list existing instances, it queries `gcloud alpha lustre instances list --location=-` and supports custom API endpoints via `CLOUDSDK_API_ENDPOINT_OVERRIDES_LUSTRE`:
+       - **Staging:** `https://staging-lustre.mtls.sandbox.googleapis.com/`
+       - **Autopush:** `https://autopush-lustre.mtls.sandbox.googleapis.com/`
+       - **Default:** Omit variable to use local environment default.
+   - **Dynamic Provisioning:** Tests dynamic volume creation via the `lustre-rwx` StorageClass.
+
+---
+
+### 3. What the Agent Does Automatically
+
+1. **Runs Local Suites First:** Executes `make unit-test`, `make sanity-test`, and `make verify`. If any fail, it self-corrects your code until all pass.
+2. **Builds & Pushes Staging Image:** Pauses for your approval, then builds and pushes a traceable staging image (`STAGINGVERSION=dev-<sha>-<timestamp>`).
+3. **Replaces Driver on GKE:** Uninstalls existing driver pods (`make uninstall`) and deploys your staging build (`make install`), monitoring `lustre-csi-node` (defined in `deploy/base/node/node.yaml` with init container `lustre-kmod-installer` and main container `lustre-csi-driver`).
+4. **Automated Deep Troubleshooting:** If any pod fails to start within **30 seconds**, the agent automatically inspects container logs (`lustre-kmod-installer` / `lustre-csi-driver`) and SSHes into the GKE node, running `lsmod | grep lustre` to verify kernel module loading before executing `dmesg`.
+5. **Verifies Active I/O:** Executes file write/read/delete tests inside the mounted Lustre volume and cleans up test workloads automatically.

--- a/.agents/skills/lustre-csi-test/SKILL.md
+++ b/.agents/skills/lustre-csi-test/SKILL.md
@@ -19,7 +19,7 @@ name: lustre-csi-test
 description: >-
   Guides local build, unit/sanity testing, and live GKE integration testing (static or dynamic provisioning)
   of the Lustre CSI Driver on Google Kubernetes Engine (GKE) nodes running Ubuntu or Container-Optimized OS (COS).
-  Use when testing local code changes or validating CSI driver builds on a GKE cluster.
+  Helps developers perform local validation, verify kernel module installation, test volume mounts, and execute simple I/O to ensure local changes conform to minimum quality standards.
 ---
 
 # Lustre CSI Driver Testing Workflow

--- a/.agents/skills/lustre-csi-test/SKILL.md
+++ b/.agents/skills/lustre-csi-test/SKILL.md
@@ -122,7 +122,7 @@ Uses `examples/pre-prov/preprov-pvc-pv.yaml` and `examples/pre-prov/preprov-pod.
        examples/pre-prov/preprov-pvc-pv.yaml | kubectl apply -f -
    kubectl apply -f examples/pre-prov/preprov-pod.yaml
    ```
-   - Expected Pod Name: `preprov-pod`
+   - Expected Pod Name: `lustre-pod`
 
 ### Mode B: Dynamic Provisioning Test
 Uses `examples/dynamic-prov/dynamic-pvc.yaml` and `examples/dynamic-prov/dynamic-pod.yaml`.
@@ -136,7 +136,7 @@ Uses `examples/dynamic-prov/dynamic-pvc.yaml` and `examples/dynamic-prov/dynamic
 ---
 
 ## Phase 4: 30-Second Pod Readiness & Deep Debugging Escalation
-1. Monitor the target test pod (`preprov-pod` for static, `lustre-pod` for dynamic).
+1. Monitor the target test pod (`lustre-pod`).
 2. **30-Second Timeout Rule:** If the pod does not reach `Running` within **30 seconds**, assume mounting failed:
    - First inspect CSI node driver logs:
      ```bash
@@ -148,12 +148,12 @@ Uses `examples/dynamic-prov/dynamic-pvc.yaml` and `examples/dynamic-prov/dynamic
 ---
 
 ## Phase 5: Active End-to-End I/O Verification & Clean Teardown
-1. Once the test pod enters `Running`, execute an interactive I/O check inside the pod (`preprov-pod` or `lustre-pod`):
+1. Once the test pod (`lustre-pod`) enters `Running`, execute an interactive I/O check inside the pod:
    ```bash
-   kubectl exec -it <pod-name> -- /bin/sh -c '
-     echo "lustre-test-data-$(date +%s)" > /mnt/lustre_volume/testfile && \
-     cat /mnt/lustre_volume/testfile && \
-     rm /mnt/lustre_volume/testfile
+   kubectl exec -it lustre-pod -- /bin/sh -c '
+     echo "lustre-test-data-$(date +%s)" > /lustre_volume/testfile && \
+     cat /lustre_volume/testfile && \
+     rm /lustre_volume/testfile
    '
    ```
    Confirm file write, read, and delete succeed without errors.

--- a/.agents/skills/lustre-csi-test/SKILL.md
+++ b/.agents/skills/lustre-csi-test/SKILL.md
@@ -1,0 +1,160 @@
+<!--
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+---
+name: lustre-csi-test
+description: >-
+  Guides local build, unit/sanity testing, and live GKE integration testing (static or dynamic provisioning)
+  of the Lustre CSI Driver on Google Kubernetes Engine (GKE) nodes running Ubuntu or Container-Optimized OS (COS).
+  Use when testing local code changes or validating CSI driver builds on a GKE cluster.
+---
+
+# Lustre CSI Driver Testing Workflow
+
+You are an expert Kubernetes and Storage engineer helping test local changes to the Lustre CSI Driver on Google Kubernetes Engine (GKE) nodes running **Ubuntu** or **Container-Optimized OS (COS)**.
+
+## Core Architecture & Debugging Rules
+### Split Architecture (Critical Knowledge)
+- **Host OS Support:** Nodes may run **Ubuntu** or **Container-Optimized OS (COS)**. The driver architecture is identical on both.
+- **Lustre Kernel Module (`kmod`):** Loaded on the host node (managed via `cos-dkms` or Secure Kernel Module Loading).
+- **Lustre Client Utilities (`lfs`, `lctl`, etc.):** **NOT installed on the host node.** They reside exclusively inside the CSI driver container image.
+- **Running Lustre Commands:** If you need to execute `lctl`, `lfs`, or other Lustre client tools for diagnostics, execute them inside the CSI node pod container:
+  ```bash
+  kubectl exec -it <lustre-csi-node-pod> -n lustre-csi-driver -c lustre-csi-driver -- /bin/sh
+  ```
+
+- **Lustre API Endpoint Overrides:** Managed Lustre supports non-prod API endpoints via `CLOUDSDK_API_ENDPOINT_OVERRIDES_LUSTRE`:
+  - **Staging:** `CLOUDSDK_API_ENDPOINT_OVERRIDES_LUSTRE=https://staging-lustre.mtls.sandbox.googleapis.com/`
+  - **Autopush:** `CLOUDSDK_API_ENDPOINT_OVERRIDES_LUSTRE=https://autopush-lustre.mtls.sandbox.googleapis.com/`
+  - **Default:** Omit variable to use local environment default.
+
+- **VPC Co-Location Requirement:** For Static Provisioning, the GKE cluster and the Managed Lustre instance MUST reside in the same VPC network. Otherwise, mounting will fail. Always verify matching networks before deploying test workloads.
+- **Node Kernel Module Verification:** Whenever SSHing into a host node (`gcloud compute ssh`), ALWAYS run `lsmod | grep lustre` first to verify whether the Lustre kernel module is loaded before inspecting kernel logs with `dmesg`.
+
+---
+
+## Phase 0: Interactive Environment Setup
+Before running any tests, explicitly prompt the user:
+1. **GCP Project & Cluster Conflict Check:**
+   - Check current project (`gcloud config get-value project`) and current `kubectl config current-context`.
+   - If there is any ambiguity or project mismatch between the local gcloud config and GKE cluster, explicitly ask: *"Which exact GCP project do you want to use?"* and run `gcloud config set project <PROJECT_NAME>`.
+2. **GKE Cluster Connection:** *"Which GKE cluster do you want to use? Please provide the cluster name, location, and project."*
+   - Connect via:
+     ```bash
+     gcloud container clusters get-credentials <cluster-name> --location <location> --project <project-name>
+     ```
+   - Record the cluster's VPC network (`gcloud container clusters describe <cluster-name> --location <location> --format='value(networkConfig.network)'`).
+3. **Provisioning Mode Selection:** *"Do you want to test with Static Provisioning using an existing Lustre instance (fastest), or Dynamic Provisioning?"*
+   - **If Static Provisioning:**
+     - Ask if the user already has the instance handle, IP, and filesystem name, OR if they want you to list existing instances using `gcloud alpha lustre instances list`.
+     - If listing existing instances, ask which API endpoint environment to use (**Staging**, **Autopush**, or **Default**) and query using:
+       ```bash
+       # Staging Example:
+       CLOUDSDK_API_ENDPOINT_OVERRIDES_LUSTRE=https://staging-lustre.mtls.sandbox.googleapis.com/ \
+         gcloud alpha lustre instances list --location=- --project=<PROJECT_NAME>
+       ```
+     - Record:
+       1. Full managed instance handle (`<project-id>/<instance-location>/<instance-name>`)
+       2. Lustre server IP address (`EXISTING_LUSTRE_IP_ADDRESS`)
+       3. Lustre filesystem name (`EXISTING_LUSTRE_FSNAME`)
+     - **MANDATORY SAME-VPC VERIFICATION:** Inspect the Lustre instance's network (`gcloud alpha lustre instances describe ... --format='value(network)'`). Confirm it matches the GKE cluster's VPC network. If they differ, STOP and inform the user immediately—mounting across separate VPCs without peering will fail.
+   - **If Dynamic Provisioning:** No existing instance details needed; the CSI driver will dynamically provision storage via `lustre-rwx` StorageClass.
+
+---
+
+## Phase 1: Local Validation & Image Build
+1. **Run Local Validation Suites:**
+   ```bash
+   make unit-test
+   make sanity-test
+   make verify
+   ```
+2. **Iterate:** Fix any build, lint, or test failures autonomously until all three commands pass cleanly.
+3. **CHECKPOINT — STOP AND WAIT:** Inform the user that local suites passed. Request permission to build and push the multi-arch staging image:
+   ```bash
+   STAGINGVERSION=dev-$(git rev-parse --short HEAD)-$(date +%m%d%H%M) make build-all-image-and-push-multi-arch
+   ```
+
+---
+
+## Phase 2: GKE Driver Replacement & Health Verification
+Only proceed after explicit user approval and successful image push.
+
+1. **Uninstall Existing Driver:**
+   ```bash
+   make uninstall
+   ```
+   Wait until all existing CSI driver resources terminate cleanly.
+2. **Install Built Driver:**
+   ```bash
+   STAGINGVERSION=<tag-from-phase-1> make install
+   ```
+3. **Verify DaemonSet & Deployment Status:** Check `kubectl get Deployment,DaemonSet,Pods -n lustre-csi-driver` until all CSI pods reach `Running`.
+4. **CSI Driver Failure Escalation Protocol:**
+   - If CSI driver pods do not enter `Running` state:
+     1. Check init container (`lustre-kmod-installer`) and main container (`lustre-csi-driver`) logs via `kubectl logs -n lustre-csi-driver <pod> -c <container>`. Note: `deploy/base/node/node.yaml` defines DaemonSet `lustre-csi-node` with init container `lustre-kmod-installer` and main container `lustre-csi-driver`.
+     2. If container logs do not explain the failure, SSH into the underlying GKE node (`gcloud compute ssh <node-name>`), run `lsmod | grep lustre` to check if the Lustre kernel module is loaded, and then run `dmesg` to inspect kernel module loading/LNet logs.
+
+---
+
+## Phase 3: Integration Testing (Static or Dynamic Provisioning)
+
+### Mode A: Static Provisioning Test (Fastest)
+Uses `examples/pre-prov/preprov-pvc-pv.yaml` and `examples/pre-prov/preprov-pod.yaml`.
+1. Substitute placeholders (`volumeHandle`, `ip`, `filesystem`) dynamically without modifying tracked git files:
+   ```bash
+   sed -e "s|<project-id>/<instance-location>/<instance-name>|$INSTANCE_HANDLE|g" \
+       -e "s|\${EXISTING_LUSTRE_IP_ADDRESS}|$LUSTRE_IP|g" \
+       -e "s|\${EXISTING_LUSTRE_FSNAME}|$FS_NAME|g" \
+       examples/pre-prov/preprov-pvc-pv.yaml | kubectl apply -f -
+   kubectl apply -f examples/pre-prov/preprov-pod.yaml
+   ```
+   - Expected Pod Name: `preprov-pod`
+
+### Mode B: Dynamic Provisioning Test
+Uses `examples/dynamic-prov/dynamic-pvc.yaml` and `examples/dynamic-prov/dynamic-pod.yaml`.
+1. Apply dynamic manifests directly:
+   ```bash
+   kubectl apply -f examples/dynamic-prov/dynamic-pvc.yaml
+   kubectl apply -f examples/dynamic-prov/dynamic-pod.yaml
+   ```
+   - Expected Pod Name: `lustre-pod`
+
+---
+
+## Phase 4: 30-Second Pod Readiness & Deep Debugging Escalation
+1. Monitor the target test pod (`preprov-pod` for static, `lustre-pod` for dynamic).
+2. **30-Second Timeout Rule:** If the pod does not reach `Running` within **30 seconds**, assume mounting failed:
+   - First inspect CSI node driver logs:
+     ```bash
+     kubectl logs -n lustre-csi-driver <node-pod> -c lustre-csi-driver
+     ```
+   - If CSI driver logs are insufficient, SSH into the GKE node (`gcloud compute ssh <node-name>`), run `lsmod | grep lustre` to verify if the Lustre kernel module is loaded, and then run `dmesg` to inspect kernel-level Lustre mount errors.
+   - If Lustre utility inspection (`lctl`, `lfs`) is needed, execute inside the CSI node driver container (`kubectl exec -it <node-pod> -n lustre-csi-driver -c lustre-csi-driver -- /bin/sh`).
+
+---
+
+## Phase 5: Active End-to-End I/O Verification & Clean Teardown
+1. Once the test pod enters `Running`, execute an interactive I/O check inside the pod (`preprov-pod` or `lustre-pod`):
+   ```bash
+   kubectl exec -it <pod-name> -- /bin/sh -c '
+     echo "lustre-test-data-$(date +%s)" > /mnt/lustre_volume/testfile && \
+     cat /mnt/lustre_volume/testfile && \
+     rm /mnt/lustre_volume/testfile
+   '
+   ```
+   Confirm file write, read, and delete succeed without errors.
+2. **Teardown:** Clean up test PV/PVC/Pod resources after verification so the cluster remains clean. Report test results to the user and remain active for further follow-up instructions.

--- a/Makefile
+++ b/Makefile
@@ -127,14 +127,10 @@ generate-spec-yaml:
 		echo "  template:" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
 		echo "    spec:" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
 		echo "      initContainers:" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
-		echo "      - name: disable-loadpin" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
-		echo "        \$$patch: delete" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
-		echo "      - name: install-lustre-mods" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
+		echo "      - name: lustre-kmod-installer" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
 		echo "        \$$patch: delete" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
 		echo "      volumes:" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
 		echo "      - name: host-modules" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
-		echo "        \$$patch: delete" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
-		echo "      - name: dev" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
 		echo "        \$$patch: delete" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
 		echo "      - name: host-etc" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \
 		echo "        \$$patch: delete" >> ./deploy/overlays/${OVERLAY}/patch-remove-kmod.yaml; \

--- a/cmd/kmod_installer/Dockerfile
+++ b/cmd/kmod_installer/Dockerfile
@@ -40,7 +40,7 @@ RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dea
     echo "deb [signed-by=/usr/share/keyrings/lustre-client.gpg] ar+https://us-apt.pkg.dev/projects/lustre-client-binaries lustre-client-ubuntu-noble main" | tee -a /etc/apt/sources.list.d/artifact-registry.list && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=gcr.io/cos-cloud/cos-dkms:v0.3.12 /usr/bin/cos-dkms /usr/bin/cos-dkms
+COPY --from=gcr.io/cos-cloud/cos-dkms:v0.3.14 /usr/bin/cos-dkms /usr/bin/cos-dkms
 COPY --from=builder /bin/lustre-kmod-installer /usr/bin/lustre-kmod-installer
 
 ENTRYPOINT ["/usr/bin/lustre-kmod-installer"]

--- a/deploy/images/gke-release/image.yaml
+++ b/deploy/images/gke-release/image.yaml
@@ -24,10 +24,10 @@ imageTag:
 apiVersion: builtin
 kind: ImageTagTransformer
 metadata:
-  name: imagetag-cos-dkms
+  name: lustre-kmod-installer
 imageTag:
-  name: gcr.io/cos-cloud/cos-dkms
-  newTag: "v0.3.9"
+  name: gke.gcr.io/lustre-kmod-installer
+  newTag: "v0.6.9-gke.4"
 ---
 apiVersion: builtin
 kind: ImageTagTransformer
@@ -35,5 +35,4 @@ metadata:
   name: imagetag-lustre-csi-driver
 imageTag:
   name: gke.gcr.io/lustre-csi-driver
-  newTag: "v0.3.14-gke.1"
-
+  newTag: "v0.6.9-gke.4"

--- a/deploy/overlays/gke-release/node.yaml
+++ b/deploy/overlays/gke-release/node.yaml
@@ -39,59 +39,41 @@ spec:
           type: RuntimeDefault
       priorityClassName: csi-lustre-node
       serviceAccount: lustre-csi-node-sa
-      nodeSelector:
-        kubernetes.io/os: linux
-        cloud.google.com/gke-os-distribution: cos
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+                  - key: cloud.google.com/gke-os-distribution
+                    operator: In
+                    values:
+                      - cos
+                      - ubuntu
       initContainers:
-      - name: disable-loadpin
-        image: gcr.io/cos-cloud/cos-dkms
-        securityContext:
-          privileged: true
-        command: ["/bin/sh", "-c"]
-        args:
-          - |
-            # Disable LoadPin if it's not already disabled
-            if cat /proc/cmdline | grep "loadpin"; then
-              echo "LoadPin has already been disabled. Move to kmod installation."
-            else
-              echo "Sleep 60s until the node is ready"
-              sleep 60
-              echo "LoadPin is not disabled. Disabling LoadPin now."
-              mkdir -p /mnt/disks
-              mount /dev/disk/by-label/EFI-SYSTEM /mnt/disks
-              sed -i -e 's|module.sig_enforce=0|module.sig_enforce=0 loadpin.enforce=0|g' /mnt/disks/efi/boot/grub.cfg
-              umount /mnt/disks
-              echo 1 > /proc/sys/kernel/sysrq
-              echo b > /proc/sysrq-trigger
-            fi
-        volumeMounts:
-        - name: dev
-          mountPath: /dev
-      - name: install-lustre-mods
-        image: gcr.io/cos-cloud/cos-dkms
-        securityContext:
-         privileged: true
-        command: ["/bin/sh", "-c"]
-        args:
-          - |
-            # Install the Lustre client drivers.
-            #
-            # --gcs-bucket: Specifies the GCS bucket containing the driver packages ('cos-default').
-            # --module-version: Sets the lustre client driver version.
-            # --kernelmodulestree: Sets the path to the kernel modules directory on the host ('/host_modules').
-            # --lsb-release-path: Specifies the path to the lsb-release file on the host ('/host_etc/lsb-release').
-            # --insert-on-install: Inserts the module into the kernel after installation.
-            # --module-arg lnet.accept_port=6988: This is crucial for setting the LNET port.
-            #                                     Lustre uses LNET for network communication, and this
-            #                                     parameter configures the port LNET will use. This is
-            #                                     essential for proper communication between Lustre clients
-            #                                     and servers. In this case, we're setting it to 6988.
-            /usr/bin/cos-dkms install lustre-client-drivers --gcs-bucket=cos-default --latest -w 0 --kernelmodulestree=/host_modules --module-arg=lnet.accept_port=6988 --lsb-release-path=/host_etc/lsb-release --insert-on-install --logtostderr
-        volumeMounts:
-        - name: host-etc
-          mountPath: /host_etc/lsb-release
-        - name: host-modules
-          mountPath: /host_modules
+        - name: lustre-kmod-installer
+          securityContext:
+            privileged: true
+          image: gke.gcr.io/lustre-kmod-installer
+          imagePullPolicy: Always
+          args:
+            - --v=5
+            - --nodeid=$(KUBE_NODE_NAME)
+            - --disable-multi-nic=false
+            - --enable-legacy-lustre-port=false
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: host-etc
+              mountPath: /host_etc/lsb-release
+            - name: host-modules
+              mountPath: /host_modules
       containers:
         - name: lustre-csi-driver
           securityContext:
@@ -122,6 +104,10 @@ spec:
               mountPropagation: "Bidirectional"
             - name: socket-dir
               mountPath: /csi
+            - name: host-udev
+              mountPath: /host_etc_udev
+            - name: dev
+              mountPath: /dev
         - name: csi-driver-registrar
           securityContext:
             readOnlyRootFilesystem: true
@@ -166,12 +152,18 @@ spec:
         - name: host-etc
           hostPath:
             path: /etc/lsb-release
+            type: File
         - name: host-modules
           hostPath:
             path: /lib/modules
+        - name: host-udev
+          hostPath:
+            path: /etc/udev
+            type: Directory
         - name: dev
           hostPath:
             path: /dev
+            type: Directory
       # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
       # See "special case". This will tolerate everything. Node component should
       # be scheduled on all nodes.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,7 +40,7 @@ limitations under the License.
 
   > Ensure that your cluster's node pool version is at least `1.31.5-gke.1299000` or `1.32.1-gke.1673000`.
   >
-  > - **For GKE version `1.34.1-gke.236400` or later**: You can use the [Container-Optimized OS with Secure Modules](https://cloud.google.com/kubernetes-engine/security/secure-modules-cos) node image. This image supports installing the Lustre kernel module without needing to disable LoadPin or reboot the node.
+  > - **For GKE version `1.34.1-gke.2364000` or later**: You can use the [Container-Optimized OS with Secure Modules](https://cloud.google.com/kubernetes-engine/security/secure-modules-cos) node image. This image supports installing the Lustre kernel module without needing to disable LoadPin or reboot the node.
   > - **For older versions**: Ensure the node image is **Container-Optimized OS with containerd** (`cos_containerd`). Additionally, verify that [Secure Boot](https://cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes#secure_boot) is disabled in your node pool (it is disabled by default in standard GKE clusters).
   > > [!IMPORTANT]
   > > To install the unmanaged Lustre CSI driver, your node pool must be created with [Secure Kernel Module Loading](https://cloud.google.com/kubernetes-engine/security/secure-modules-cos) enabled on non-GPU nodes. This is required because the driver loads Lustre kernel modules dynamically, which COS blocks by default unless Secure Kernel Module Loading is enabled or LoadPin is disabled manually on the node.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -42,6 +42,8 @@ limitations under the License.
   >
   > - **For GKE version `1.34.1-gke.236400` or later**: You can use the [Container-Optimized OS with Secure Modules](https://cloud.google.com/kubernetes-engine/security/secure-modules-cos) node image. This image supports installing the Lustre kernel module without needing to disable LoadPin or reboot the node.
   > - **For older versions**: Ensure the node image is **Container-Optimized OS with containerd** (`cos_containerd`). Additionally, verify that [Secure Boot](https://cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes#secure_boot) is disabled in your node pool (it is disabled by default in standard GKE clusters).
+  > > [!IMPORTANT]
+  > > To install the unmanaged Lustre CSI driver, your node pool must be created with [Secure Kernel Module Loading](https://cloud.google.com/kubernetes-engine/security/secure-modules-cos) enabled on non-GPU nodes. This is required because the driver loads Lustre kernel modules dynamically, which COS blocks by default unless Secure Kernel Module Loading is enabled or LoadPin is disabled manually on the node.
 
 - Run the following command to ensure the kubectl context is set up correctly.
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -48,7 +48,7 @@ curl -fsSL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
     - Run the [gsa_setup script](../deploy/base/setup/gsa_setup.sh) to configure the service account:
 
     ```sh
-    ../deploy/base/setup/gsa_setup.sh
+    ./deploy/base/setup/gsa_setup.sh
     ```
 
     - Create a Kubernetes secret from the service account key:
@@ -66,7 +66,7 @@ curl -fsSL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
 3. Install the csi driver using helm
 
     ```sh
-    helm upgrade -i lustre-csi-driver lustre-csi-driver \
+    helm upgrade -i lustre-csi-driver ./helm/lustre-csi-driver \
       --namespace ${NAMESPACE} \
       --set image.lustre.tag="$VERSION"
     ```

--- a/helm/lustre-csi-driver/Chart.yaml
+++ b/helm/lustre-csi-driver/Chart.yaml
@@ -29,10 +29,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.12"
+appVersion: "0.4.13"

--- a/helm/lustre-csi-driver/templates/csi-node.yaml
+++ b/helm/lustre-csi-driver/templates/csi-node.yaml
@@ -44,16 +44,20 @@ spec:
       initContainers:
       - name: lustre-kmod-installer
         image: "{{ .Values.image.kmod.repository }}:{{ .Values.image.kmod.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.kmod.pullPolicy | default "Always" }}
         securityContext:
-         privileged: true
+          privileged: true
+        args:
+          - --v=5
+          - --nodeid=$(KUBE_NODE_NAME)
+          - --enable-legacy-lustre-port={{ .Values.image.kmod.enableLegacyLustrePort }}
+          - --disable-multi-nic={{ .Values.image.kmod.disableMultiNic }}
         env:
-        - name: ENABLE_LEGACY_LUSTRE_PORT
-          value: "true"
-        - name: CHECK_LOADPIN
-          value: "true"
+          - name: KUBE_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
         volumeMounts:
-        - name: dev
-          mountPath: /dev
         - name: host-etc
           mountPath: /host_etc/lsb-release
         - name: host-modules
@@ -88,6 +92,10 @@ spec:
               mountPropagation: "Bidirectional"
             - name: socket-dir
               mountPath: /csi
+            - name: host-udev
+              mountPath: /host_etc_udev
+            - name: dev
+              mountPath: /dev
         - name: csi-driver-registrar
           securityContext:
             readOnlyRootFilesystem: true
@@ -136,8 +144,13 @@ spec:
         - name: host-modules
           hostPath:
             path: /lib/modules
+        - name: host-udev
+          hostPath:
+            path: /etc/udev
+            type: Directory
         - name: dev
           hostPath:
             path: /dev
+            type: Directory
       tolerations:
         - operator: Exists

--- a/helm/lustre-csi-driver/values.yaml
+++ b/helm/lustre-csi-driver/values.yaml
@@ -20,12 +20,14 @@
 image:
   lustre:
     repository: "us.gcr.io/gke-release/lustre-csi-driver"
-    tag: v0.4.12-gke.0
+    tag: v0.6.9-gke.4
     pullPolicy: Always
   kmod:
     repository: "us.gcr.io/gke-release/lustre-kmod-installer"
-    tag: v0.4.12-gke.0
+    tag: v0.6.9-gke.4
     pullPolicy: Always
+    enableLegacyLustrePort: false
+    disableMultiNic: false
 
 sidecars:
   image:

--- a/pkg/csi_driver/node.go
+++ b/pkg/csi_driver/node.go
@@ -49,6 +49,7 @@ type nodeServer struct {
 	driver      *LustreDriver
 	mounter     mount.Interface
 	volumeLocks *util.VolumeLocks
+	unmountExec unmountExecFunc
 }
 
 func newNodeServer(driver *LustreDriver, mounter mount.Interface) csi.NodeServer {
@@ -74,7 +75,7 @@ func (s *nodeServer) NodeGetCapabilities(_ context.Context, _ *csi.NodeGetCapabi
 	}, nil
 }
 
-func (s *nodeServer) NodeStageVolume(_ context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
+func (s *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID not provided")
@@ -190,8 +191,8 @@ func (s *nodeServer) NodeStageVolume(_ context.Context, req *csi.NodeStageVolume
 	klog.V(4).Infof("NodeStageVolume mounting volume %s to path %s on node %s with mountOptions %v", volumeID, target, nodeName, mountOptions)
 	if err := s.mounter.MountSensitiveWithoutSystemd(source, target, "lustre", mountOptions, nil); err != nil {
 		klog.Errorf("Mount %q failed on node %s, cleaning up", target, nodeName)
-		if unmntErr := mount.CleanupMountPoint(target, s.mounter, false /* extensiveMountPointCheck */); unmntErr != nil {
-			klog.Errorf("Unmount %q failed on node %s: %v", target, nodeName, unmntErr.Error())
+		if unmntErr := s.unmountPath(target); unmntErr != nil {
+			klog.Errorf("Unmount %q failed on node %s: %v", target, nodeName, unmntErr)
 		}
 
 		return nil, status.Errorf(codes.Internal, "Could not mount %q at %q on node %s: %v", source, target, nodeName, err)
@@ -202,7 +203,7 @@ func (s *nodeServer) NodeStageVolume(_ context.Context, req *csi.NodeStageVolume
 	return &csi.NodeStageVolumeResponse{}, nil
 }
 
-func (s *nodeServer) NodeUnstageVolume(_ context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
+func (s *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID not provided")
@@ -218,22 +219,9 @@ func (s *nodeServer) NodeUnstageVolume(_ context.Context, req *csi.NodeUnstageVo
 	}
 	defer s.volumeLocks.Release(target)
 
-	// Check if the target path is mounted before unmounting.
-	if notMnt, _ := s.mounter.IsLikelyNotMountPoint(target); notMnt {
-		klog.V(5).InfoS("NodeUnstageVolume: staging target path not mounted, skipping unmount", "staging target", target)
-
-		return &csi.NodeUnstageVolumeResponse{}, nil
-	}
-	// Always unmount the target path regardless of the detected mount state.
-	// In cases where Lustre was force-unmounted, CleanupMountPoint may fail
-	// to detect the state and error out with "cannot send after transport endpoint shutdown".
 	klog.V(5).InfoS("NodeUnstageVolume attempting to unmount", "staging target", target)
-	if err := s.mounter.Unmount(target); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to unmount staging target %q: %v", target, err)
-	}
-
-	if err := mount.CleanupMountPoint(target, s.mounter, false /* extensiveMountPointCheck */); err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+	if err := s.unmountPath(target); err != nil {
+		return nil, err
 	}
 
 	klog.V(4).Infof("NodeUnstageVolume succeeded on volume %v from staging target path %s on node %s", volumeID, target, s.driver.config.NodeID)
@@ -241,7 +229,7 @@ func (s *nodeServer) NodeUnstageVolume(_ context.Context, req *csi.NodeUnstageVo
 	return &csi.NodeUnstageVolumeResponse{}, nil
 }
 
-func (s *nodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+func (s *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID not provided")
@@ -299,9 +287,9 @@ func (s *nodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishVo
 
 	if mounted {
 		if err := setVolumeOwnershipTopLevel(volumeID, targetPath, fsGroup, ro); err != nil {
-			klog.Infof("setVolumeOwnershipTopLevel failed for volume %q, path %q, fsGroup %q, cleaning up mount point on node %s", volumeID, targetPath, fsGroup, nodeName)
-			if unmntErr := mount.CleanupMountPoint(targetPath, s.mounter, false /* extensiveMountPointCheck */); unmntErr != nil {
-				klog.Errorf("Unmount %q failed on node %s: %v", targetPath, nodeName, unmntErr.Error())
+			klog.V(5).Infof("setVolumeOwnershipTopLevel failed for volume %q, path %q, fsGroup %q, cleaning up mount point on node %s", volumeID, targetPath, fsGroup, nodeName)
+			if unmntErr := s.unmountPath(targetPath); unmntErr != nil {
+				klog.Errorf("Unmount %q failed on node %s: %v", targetPath, nodeName, unmntErr)
 			}
 
 			return nil, status.Error(codes.Internal, err.Error())
@@ -327,9 +315,9 @@ func (s *nodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishVo
 	klog.V(4).Infof("NodePublishVolume successfully mounted %s on node %s", targetPath, nodeName)
 
 	if err := setVolumeOwnershipTopLevel(volumeID, targetPath, fsGroup, ro); err != nil {
-		klog.Infof("setVolumeOwnershipTopLevel failed for volume %q, path %q, fsGroup %q, cleaning up mount point on node %s", volumeID, targetPath, fsGroup, nodeName)
-		if unmntErr := mount.CleanupMountPoint(targetPath, s.mounter, false /* extensiveMountPointCheck */); unmntErr != nil {
-			klog.Errorf("Unmount %q failed on node %s: %v", targetPath, nodeName, unmntErr.Error())
+		klog.V(5).Infof("setVolumeOwnershipTopLevel failed for volume %q, path %q, fsGroup %q, cleaning up mount point on node %s", volumeID, targetPath, fsGroup, nodeName)
+		if unmntErr := s.unmountPath(targetPath); unmntErr != nil {
+			klog.Errorf("Unmount %q failed on node %s: %v", targetPath, nodeName, unmntErr)
 		}
 
 		return nil, status.Error(codes.Internal, err.Error())
@@ -338,7 +326,7 @@ func (s *nodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishVo
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 
-func (s *nodeServer) NodeUnpublishVolume(_ context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+func (s *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
 	// Validate arguments.
 	targetPath := req.GetTargetPath()
 	if len(targetPath) == 0 {
@@ -351,22 +339,9 @@ func (s *nodeServer) NodeUnpublishVolume(_ context.Context, req *csi.NodeUnpubli
 	}
 	defer s.volumeLocks.Release(targetPath)
 
-	// Check if the target path is mounted before unmounting.
-	if notMnt, _ := s.mounter.IsLikelyNotMountPoint(targetPath); notMnt {
-		klog.V(5).InfoS("NodeUnpublishVolume: target path not mounted, skipping unmount", "target", targetPath)
-
-		return &csi.NodeUnpublishVolumeResponse{}, nil
-	}
-	// Always unmount the target path regardless of the detected mount state.
-	// In cases where Lustre was force-unmounted, CleanupMountPoint may fail
-	// to detect the state and error out with "cannot send after transport endpoint shutdown".
 	klog.V(5).InfoS("NodeUnpublishVolume attempting to unmount", "target", targetPath)
-	if err := s.mounter.Unmount(targetPath); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to unmount target %q: %v", targetPath, err)
-	}
-
-	if err := mount.CleanupMountPoint(targetPath, s.mounter, false /* extensiveMountPointCheck */); err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+	if err := s.unmountPath(targetPath); err != nil {
+		return nil, err
 	}
 
 	return &csi.NodeUnpublishVolumeResponse{}, nil

--- a/pkg/csi_driver/unmount.go
+++ b/pkg/csi_driver/unmount.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/klog/v2"
+	mount "k8s.io/mount-utils"
+)
+
+const (
+	// DefaultUnmountTimeout is the maximum duration to wait for a standard umount.
+	DefaultUnmountTimeout = 15 * time.Second
+	// DefaultForceUnmountTimeout is the maximum duration to wait for a force umount (-f).
+	DefaultForceUnmountTimeout = 10 * time.Second
+	// DefaultLazyUnmountTimeout is the maximum duration to wait for a lazy umount (-l).
+	DefaultLazyUnmountTimeout = 5 * time.Second
+
+	errNotMounted = "not mounted"
+)
+
+type unmountExecFunc func(ctx context.Context, args ...string) ([]byte, error)
+
+// execUmount executes umount with given arguments and context without blocking on D-state tasks.
+func (s *nodeServer) execUmount(ctx context.Context, args ...string) ([]byte, error) {
+	if s.unmountExec != nil {
+		return s.unmountExec(ctx, args...)
+	}
+
+	// In test environments using FakeMounter, delegate to FakeMounter.Unmount if no custom unmountExec is set.
+	if fm := extractFakeMounter(s.mounter); fm != nil {
+		var target string
+		if len(args) > 0 {
+			target = args[len(args)-1]
+		}
+		err := fm.Unmount(target)
+		return nil, err
+	}
+
+	cmd := exec.Command("umount", args...)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	select {
+	case err := <-done:
+		return buf.Bytes(), err
+	case <-ctx.Done():
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		return nil, ctx.Err()
+	}
+}
+
+// unmountPath unmounts the target path using a cascading fallback strategy:
+// 1. Standard umount (DefaultUnmountTimeout = 15s)
+// 2. Force umount -f (DefaultForceUnmountTimeout = 10s) if standard umount times out or fails
+// 3. Lazy umount -l (DefaultLazyUnmountTimeout = 5s) if force umount times out or fails
+// After successfully detaching the mount, the directory is deleted.
+//
+// NOTE on Context Handling:
+// unmountPath intentionally does NOT accept or derive from the caller's gRPC context.
+// Instead, it manages its own internal timeouts using context.Background().
+// Rationale: If a caller's request context was cancelled or timed out (e.g. Kubelet 2-minute deadline
+// or client disconnect), deriving from that cancelled context would cause all three unmount phases
+// to abort immediately without actually executing umount -f or umount -l.
+// Because unmounting is a critical cleanup operation, it must run to completion to prevent leaked
+// mount points and wedged kernel/lock states. The total execution time is strictly bounded by
+// DefaultUnmountTimeout + DefaultForceUnmountTimeout + DefaultLazyUnmountTimeout (<= 30s), which is
+// well within Kubelet's retry timeout.
+func (s *nodeServer) unmountPath(target string) error {
+	notMnt, err := s.mounter.IsLikelyNotMountPoint(target)
+	if err != nil && !os.IsNotExist(err) {
+		if isCorruptedMnt(err) {
+			klog.V(4).Infof("unmountPath: target %q is corrupted mount, proceeding with unmount", target)
+		} else {
+			klog.Warningf("unmountPath: error checking if %q is a mount point: %v, proceeding with unmount", target, err)
+		}
+		notMnt = false
+	}
+
+	if notMnt {
+		klog.V(5).Infof("unmountPath: target path %s is not mounted, removing directory", target)
+		return removeDir(target)
+	}
+
+	// Phase 1: Standard unmount with bounded timeout
+	klog.V(4).Infof("unmountPath: attempting standard unmount on %s", target)
+	ctxStandard, cancelStandard := context.WithTimeout(context.Background(), DefaultUnmountTimeout)
+	out, err := s.execUmount(ctxStandard, target)
+	cancelStandard()
+
+	if err == nil || isNotMounted(err, out) {
+		klog.V(4).Infof("unmountPath: standard unmount succeeded on %s", target)
+		return removeDir(target)
+	}
+
+	// Phase 2: Force unmount (-f) with bounded timeout
+	klog.Warningf("unmountPath: standard unmount failed or timed out on %s (err: %v, out: %s). Attempting force unmount (umount -f)...", target, err, string(out))
+	ctxForce, cancelForce := context.WithTimeout(context.Background(), DefaultForceUnmountTimeout)
+	out, err = s.execUmount(ctxForce, "-f", target)
+	cancelForce()
+
+	if err == nil || isNotMounted(err, out) {
+		klog.V(4).Infof("unmountPath: force unmount succeeded on %s", target)
+		return removeDir(target)
+	}
+
+	// Phase 3: Lazy unmount (-l / MNT_DETACH) as ultimate fallback to avoid wedging the node
+	klog.Warningf("unmountPath: force unmount failed or timed out on %s (err: %v, out: %s). Falling back to lazy unmount (umount -l)...", target, err, string(out))
+	ctxLazy, cancelLazy := context.WithTimeout(context.Background(), DefaultLazyUnmountTimeout)
+	out, err = s.execUmount(ctxLazy, "-l", target)
+	cancelLazy()
+
+	if err == nil || isNotMounted(err, out) {
+		klog.V(4).Infof("unmountPath: lazy unmount succeeded on %s", target)
+		return removeDir(target)
+	}
+
+	return status.Errorf(codes.Internal, "failed to unmount target %q after standard, force, and lazy attempts: %v (output: %s)", target, err, string(out))
+}
+
+func isNotMounted(err error, output []byte) bool {
+	if err != nil && strings.Contains(strings.ToLower(err.Error()), errNotMounted) {
+		return true
+	}
+	if strings.Contains(strings.ToLower(string(output)), errNotMounted) {
+		return true
+	}
+	return false
+}
+
+func extractFakeMounter(m mount.Interface) *mount.FakeMounter {
+	if m == nil {
+		return nil
+	}
+	if fm, ok := m.(*mount.FakeMounter); ok {
+		return fm
+	}
+	// Check if the mounter embeds *mount.FakeMounter (e.g. fakeMounter in tests)
+	val := reflect.ValueOf(m)
+	if val.Kind() == reflect.Ptr && !val.IsNil() {
+		val = val.Elem()
+	}
+	if val.Kind() == reflect.Struct {
+		field := val.FieldByName("FakeMounter")
+		if field.IsValid() {
+			if fm, ok := field.Interface().(*mount.FakeMounter); ok {
+				return fm
+			}
+		}
+	}
+	return nil
+}
+
+func removeDir(target string) error {
+	if err := os.Remove(target); err != nil && !os.IsNotExist(err) {
+		return status.Errorf(codes.Internal, "failed to remove mount directory %q: %v", target, err)
+	}
+	return nil
+}

--- a/pkg/csi_driver/unmount_test.go
+++ b/pkg/csi_driver/unmount_test.go
@@ -1,0 +1,270 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	csi "github.com/container-storage-interface/spec/lib/go/csi"
+	mount "k8s.io/mount-utils"
+)
+
+func TestUnmountPath_CascadingFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		mounts        []mount.MountPoint
+		execResponses map[string]struct {
+			out []byte
+			err error
+		}
+		expectedCalls    []string
+		expectErr        bool
+		dirExistsBefore  bool
+		expectDirRemoved bool
+	}{
+		{
+			name: "Standard unmount succeeds on first attempt",
+			mounts: []mount.MountPoint{
+				{Device: testDevice, Path: "/test/staging"},
+			},
+			execResponses: map[string]struct {
+				out []byte
+				err error
+			}{
+				"umount /test/staging": {out: nil, err: nil},
+			},
+			expectedCalls:    []string{"umount /test/staging"},
+			expectErr:        false,
+			dirExistsBefore:  true,
+			expectDirRemoved: true,
+		},
+		{
+			name: "Standard unmount fails, force unmount (-f) succeeds",
+			mounts: []mount.MountPoint{
+				{Device: testDevice, Path: "/test/staging"},
+			},
+			execResponses: map[string]struct {
+				out []byte
+				err error
+			}{
+				"umount /test/staging":    {out: []byte("device busy"), err: errors.New("exit status 32")},
+				"umount -f /test/staging": {out: nil, err: nil},
+			},
+			expectedCalls: []string{
+				"umount /test/staging",
+				"umount -f /test/staging",
+			},
+			expectErr:        false,
+			dirExistsBefore:  true,
+			expectDirRemoved: true,
+		},
+		{
+			name: "Standard and force unmount fail, lazy unmount (-l) succeeds",
+			mounts: []mount.MountPoint{
+				{Device: testDevice, Path: "/test/staging"},
+			},
+			execResponses: map[string]struct {
+				out []byte
+				err error
+			}{
+				"umount /test/staging":    {out: []byte("target is busy"), err: errors.New("exit status 32")},
+				"umount -f /test/staging": {out: []byte("operation not supported"), err: errors.New("exit status 1")},
+				"umount -l /test/staging": {out: nil, err: nil},
+			},
+			expectedCalls: []string{
+				"umount /test/staging",
+				"umount -f /test/staging",
+				"umount -l /test/staging",
+			},
+			expectErr:        false,
+			dirExistsBefore:  true,
+			expectDirRemoved: true,
+		},
+		{
+			name: "All unmount attempts fail, returns error",
+			mounts: []mount.MountPoint{
+				{Device: testDevice, Path: "/test/staging"},
+			},
+			execResponses: map[string]struct {
+				out []byte
+				err error
+			}{
+				"umount /test/staging":    {out: []byte("error 1"), err: errors.New("exit status 1")},
+				"umount -f /test/staging": {out: []byte("error 2"), err: errors.New("exit status 2")},
+				"umount -l /test/staging": {out: []byte("fatal error"), err: errors.New("exit status 3")},
+			},
+			expectedCalls: []string{
+				"umount /test/staging",
+				"umount -f /test/staging",
+				"umount -l /test/staging",
+			},
+			expectErr:        true,
+			dirExistsBefore:  true,
+			expectDirRemoved: false,
+		},
+		{
+			name:   "Path is not a mount point, cleans up directory directly",
+			mounts: []mount.MountPoint{},
+			execResponses: map[string]struct {
+				out []byte
+				err error
+			}{},
+			expectedCalls:    nil,
+			expectErr:        false,
+			dirExistsBefore:  true,
+			expectDirRemoved: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			targetPath := filepath.Join(tmpDir, "staging")
+
+			if tc.dirExistsBefore {
+				if err := os.MkdirAll(targetPath, 0750); err != nil {
+					t.Fatalf("Failed to create test directory: %v", err)
+				}
+			}
+
+			// Adjust mount paths to match targetPath
+			var mountPoints []mount.MountPoint
+			for _, m := range tc.mounts {
+				mountPoints = append(mountPoints, mount.MountPoint{
+					Device: m.Device,
+					Path:   targetPath,
+				})
+			}
+
+			fm := &mount.FakeMounter{MountPoints: mountPoints}
+			testEnv := initTestNodeServer(t)
+			ns := testEnv.ns.(*nodeServer)
+			ns.mounter = fm
+
+			var mu sync.Mutex
+			var recordedCalls []string
+
+			ns.unmountExec = func(ctx context.Context, args ...string) ([]byte, error) {
+				mu.Lock()
+				defer mu.Unlock()
+
+				callKey := "umount"
+				for _, arg := range args {
+					if arg == targetPath {
+						callKey += " /test/staging"
+					} else {
+						callKey += " " + arg
+					}
+				}
+				recordedCalls = append(recordedCalls, callKey)
+
+				resp, exists := tc.execResponses[callKey]
+				if !exists {
+					return nil, errors.New("unexpected command call: " + callKey)
+				}
+				return resp.out, resp.err
+			}
+
+			err := ns.unmountPath(targetPath)
+			if (err != nil) != tc.expectErr {
+				t.Fatalf("unmountPath() error = %v, expectErr = %v", err, tc.expectErr)
+			}
+
+			mu.Lock()
+			if len(recordedCalls) != len(tc.expectedCalls) {
+				t.Errorf("Recorded calls = %v, expected = %v", recordedCalls, tc.expectedCalls)
+			} else {
+				for i := range recordedCalls {
+					if recordedCalls[i] != tc.expectedCalls[i] {
+						t.Errorf("Call %d = %q, expected %q", i, recordedCalls[i], tc.expectedCalls[i])
+					}
+				}
+			}
+			mu.Unlock()
+
+			_, statErr := os.Stat(targetPath)
+			dirExists := !os.IsNotExist(statErr)
+			if tc.expectDirRemoved && dirExists {
+				t.Errorf("Expected directory %s to be removed, but it still exists", targetPath)
+			}
+			if !tc.expectDirRemoved && tc.dirExistsBefore && !dirExists {
+				t.Errorf("Expected directory %s to remain, but it was removed", targetPath)
+			}
+		})
+	}
+}
+
+func TestUnmountPath_ContextTimeoutAndLockRelease(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	targetPath := filepath.Join(tmpDir, "staging")
+	if err := os.MkdirAll(targetPath, 0750); err != nil {
+		t.Fatalf("Failed to create test directory: %v", err)
+	}
+
+	fm := &mount.FakeMounter{
+		MountPoints: []mount.MountPoint{
+			{Device: testDevice, Path: targetPath},
+		},
+	}
+	testEnv := initTestNodeServer(t)
+	ns := testEnv.ns.(*nodeServer)
+	ns.mounter = fm
+
+	// Simulate hanging commands that simulate timeout / deadline exceeded
+	ns.unmountExec = func(ctx context.Context, args ...string) ([]byte, error) {
+		return nil, context.DeadlineExceeded
+	}
+
+	req := &csi.NodeUnstageVolumeRequest{
+		VolumeId:          testVolumeID,
+		StagingTargetPath: targetPath,
+	}
+
+	start := time.Now()
+	_, err := ns.NodeUnstageVolume(context.Background(), req)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("Expected NodeUnstageVolume to fail due to timeout, got success")
+	}
+
+	// Verify that the call returned promptly without blocking forever
+	if elapsed > 2*time.Second {
+		t.Errorf("NodeUnstageVolume took %v, expected return within ~1s", elapsed)
+	}
+
+	// CRITICAL TEST: Verify that the volume lock was released so that a subsequent call can acquire it
+	acquired := ns.volumeLocks.TryAcquire(targetPath)
+	if !acquired {
+		t.Errorf("Volume lock for %s was not released after NodeUnstageVolume failure!", targetPath)
+	} else {
+		ns.volumeLocks.Release(targetPath)
+	}
+}

--- a/test/k8s-integration/config/storage-class.yaml
+++ b/test/k8s-integration/config/storage-class.yaml
@@ -24,6 +24,16 @@ allowedTopologies:
     - key: "topology.gke.io/zone"
       values:
         - us-central1-a
+        - us-central1-b
+        - us-central1-c
+        - us-central1-f
+        - us-east4-a
+        - us-east4-b
+        - us-east4-c
+        - us-east5-b
+        - us-south1-b
+        - us-west1-b
+        - us-west1-c
 parameters:
   network: lustre-network
   perUnitStorageThroughput: "1000"

--- a/test/k8s-integration/config/storage-class.yaml
+++ b/test/k8s-integration/config/storage-class.yaml
@@ -23,18 +23,13 @@ allowedTopologies:
   - matchLabelExpressions:
     - key: "topology.gke.io/zone"
       values:
+        # These zones are known to support 'CreateInstanceOverrides' lustre backend operation.
+        # We will add more zones that has `CreateInstanceOverrides` support overtime.
         - us-central1-a
-        - us-central1-b
         - us-central1-c
-        - us-central1-f
-        - us-east4-a
-        - us-east4-b
-        - us-east4-c
-        - us-east5-b
-        - us-south1-b
-        - us-west1-b
-        - us-west1-c
+        - us-west2-a
 parameters:
   network: lustre-network
   perUnitStorageThroughput: "1000"
   labels: "gke-testing-project=prow"
+  description: 'CreateInstanceOverrides={"CalculatorType": "C4_THIN"}'

--- a/test/k8s-integration/config/storage-class.yaml
+++ b/test/k8s-integration/config/storage-class.yaml
@@ -31,4 +31,4 @@ parameters:
   network: lustre-network
   perUnitStorageThroughput: "1000"
   labels: "gke-testing-project=prow"
-  description: 'CreateInstanceOverrides={"CalculatorType": "C4_THIN"}'
+  description: 'CreateInstanceOverrides={"CalculatorType": "THIN_CLUSTER"}'

--- a/test/k8s-integration/config/storage-class.yaml
+++ b/test/k8s-integration/config/storage-class.yaml
@@ -27,7 +27,6 @@ allowedTopologies:
         # We will add more zones that has `CreateInstanceOverrides` support overtime.
         - us-central1-a
         - us-central1-c
-        - us-west2-a
 parameters:
   network: lustre-network
   perUnitStorageThroughput: "1000"

--- a/test/k8s-integration/driver-config.go
+++ b/test/k8s-integration/driver-config.go
@@ -40,7 +40,7 @@ const (
 	configFile         = "test-config.yaml"
 
 	// configurable timeouts for the k8s e2e testsuites.
-	podStartTimeout       = "600s"
+	podStartTimeout       = "1800s"
 	claimProvisionTimeout = "3600s"
 	pvDeleteTimeout       = "3600s"
 
@@ -86,26 +86,14 @@ func generateDriverConfigFile(testParams *testParameters, storageClassFile strin
 		pvDeleteTimeoutKey:       pvDeleteTimeout,
 	}
 
-	minVolumeSize := "1Ti"
-	if testParams.gkeManagedDriver {
-		minSupportedVersion := "1.34.1"
-		clusterVer, err := parseVersion(testParams.clusterVersion)
-		if err != nil {
-			return "", err
-		}
-		ver, _ := parseVersion(minSupportedVersion)
-		if !clusterVer.lessThan(ver) {
-			minVolumeSize = "9000Gi"
-		} else {
-			minVolumeSize = "18000Gi"
-		}
-	}
+	// thinInstanceMinSize represents the size for thin client Lustre instances.
+	thinInstanceMinSize := "1024Gi"
 
 	params := driverConfig{
 		StorageClassFile:  filepath.Join(testParams.pkgDir, testConfigDir, storageClassFile),
 		StorageClass:      storageClassFile[:strings.LastIndex(storageClassFile, ".")],
 		Capabilities:      caps,
-		MinimumVolumeSize: minVolumeSize,
+		MinimumVolumeSize: thinInstanceMinSize,
 		Timeouts:          timeouts,
 	}
 

--- a/test/run-k8s-integration-local.sh
+++ b/test/run-k8s-integration-local.sh
@@ -26,5 +26,5 @@ multivolume_fs_test_focus="External.*Storage.*filesystem.*multiVolume"
 # E.g. run command: test/run-k8s-integration-local.sh | tee log
 "${PKGDIR}"/bin/k8s-integration-test --run-in-prow=false --pkg-dir="${PKGDIR}" \
 --bringup-cluster=true --test-focus="${all_external_tests_focus}" --do-network-setup=true \
---do-driver-build=true --gce-zone="us-central1-c" --use-gke-driver=false \
---num-nodes="${NUM_NODES:-1}" --multi-nic-num-nodes="${MULTI_NIC_NUM_NODES:-1}" --parallel=1 -test-version=1.32 --gke-cluster-version=1.32 --image-type="${IMAGE_TYPE:-cos_containerd}"
+--do-driver-build=true --gce-zone="us-central1-a" --use-gke-driver=false \
+--num-nodes="${NUM_NODES:-1}" --multi-nic-num-nodes="${MULTI_NIC_NUM_NODES:-1}" --parallel=1 --test-version=1.36 --gke-cluster-version=1.36 --image-type="${IMAGE_TYPE:-cos_containerd}"


### PR DESCRIPTION
This PR backports 11 non-IAM feature, documentation, test, and stability fixes from `main` onto `release-0.6` in preparation for release tag `v0.6.10`:

- Modify gke-release to utilize new lustre-kmod-installer setup (PR #550 / `76988900`)
- Update cos-dkms version to v0.3.14 (PR #552 / `23c4f595`)
- docs: fix GKE version typo and update Helm deployment paths (PR #562 / `7532cf34`)
- test: extend allowed topologies in integration test storage class (PR #572 / `87cf192d`)
- Add lustre-csi-test AI agent skill for GKE testing (PR #583 / `2596587a`, `9b1d8f5b`, `1c8a85ce`)
- Using Lustre CreateInstanceOverride for smaller clients to prevent stockouts (PR #590 / `3fe3cad8`)
- Remove us-west2-a due to PermissionDenied storageclass provision (PR #600 / `f9dfaec9`)
- Replace C4_Thin to THIN_CLUSTER for better availability (PR #601 / `66a62c21`)
- **CRITICAL FIX**: fix(node): prevent unmount hangs and volumeLock deadlocks with cascading fallback (PR #618 / `9b37e155`)

### Note on Conflict Resolution
In PR #618, merge conflicts in `pkg/csi_driver/node.go` were resolved by adapting the new three-tier cascading fallback unmount implementation (`unmountPath`) while omitting the in-development Workload Identity IAM lifecycle and reference counting methods (`publishIAMVolume`, `cleanUpIAMReference`, `mountGlobalIAM`, etc.), which remain on `main`.
