### PR TITLE
refactoring storage class to split staging and prod endpoints for accurate zone selection to prevent stockouts

### DIFF
--- a/test/k8s-integration/config/storage-class-staging.yaml
+++ b/test/k8s-integration/config/storage-class-staging.yaml
@@ -25,12 +25,9 @@ allowedTopologies:
       values:
         # These zones are known to support 'CreateInstanceOverrides' lustre backend operation.
         # We will add more zones that has `CreateInstanceOverrides` support overtime.
-        - us-west2-a
-        - us-west2-b
-        - us-west2-c
-        - us-west1-a
-        - us-west1-b
         - us-west1-c
+        - us-west1-b
+        - us-south1-b
 parameters:
   network: lustre-network
   perUnitStorageThroughput: "1000"

--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -96,6 +96,12 @@ func main() {
 	}
 	flag.Parse()
 
+	if *storageClassFiles == "storage-class.yaml" {
+		if *lustreEndpoint == "staging" {
+			*storageClassFiles = "storage-class-staging.yaml"
+		}
+	}
+
 	if *inProw {
 		*doNetworkSetup = true
 		*bringupCluster = true


### PR DESCRIPTION
Splits staging and prod endpoints into separate storage classes to avoid Kubernetes topology zone-affinity mismatches when provisioning managed Lustre clusters.