### PR TITLE
fix(logging): sanitize gRPC request secrets and avoid printing raw cl…

### DIFF
--- a/pkg/cloud_provider/lustre/cloud.go
+++ b/pkg/cloud_provider/lustre/cloud.go
@@ -116,7 +116,7 @@ func maybeReadConfig(configPath string) (*ConfigFile, error) {
 	if err := gcfg.FatalOnly(gcfg.ReadInto(cfg, reader)); err != nil {
 		return nil, fmt.Errorf("couldn't read cloud provider configuration at %s: %w", configPath, err)
 	}
-	klog.Infof("Config file read %#v", cfg)
+	klog.Infof("Config file read successfully for project %s, zone %s", cfg.Global.ProjectID, cfg.Global.Zone)
 
 	return cfg, nil
 }

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -54,7 +54,7 @@ func NewNodeServiceCapability(c csi.NodeServiceCapability_RPC_Type) *csi.NodeSer
 }
 
 func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-	klog.V(5).Infof("GRPC call: %s, GRPC request: %+v", info.FullMethod, pbSanitizer.StripSecretsCSI03(req).String())
+	klog.V(5).Infof("GRPC call: %s, GRPC request: %+v", info.FullMethod, pbSanitizer.StripSecrets(req).String())
 	resp, err := handler(ctx, req)
 	if err != nil {
 		klog.Errorf("GRPC call: %s, GRPC error: %v", info.FullMethod, err.Error())

--- a/pkg/csi_driver/utils.go
+++ b/pkg/csi_driver/utils.go
@@ -54,7 +54,7 @@ func NewNodeServiceCapability(c csi.NodeServiceCapability_RPC_Type) *csi.NodeSer
 }
 
 func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-	klog.V(5).Infof("GRPC call: %s, GRPC request: %+v", info.FullMethod, pbSanitizer.StripSecrets(req).String())
+	klog.V(5).Infof("GRPC call: %s, GRPC request: %+v", info.FullMethod, pbSanitizer.StripSecrets(req))
 	resp, err := handler(ctx, req)
 	if err != nil {
 		klog.Errorf("GRPC call: %s, GRPC error: %v", info.FullMethod, err.Error())


### PR DESCRIPTION
    - Update maybeReadConfig in cloud provider to log only ProjectID and Zone upon successfully reading configuration instead of printing the entire cfg struct (%#v), preventing potential plaintext log exposure of internal configuration details.
    - Update logGRPC interceptor to use pbSanitizer.StripSecrets instead of legacy pbSanitizer.StripSecretsCSI03 to ensure sensitive request payloads are properly sanitized for modern CSI proto calls.