### PR TITLE
Update cos-dkms version to v0.3.16 to fix CVEs

### DIFF
--- a/cmd/kmod_installer/Dockerfile
+++ b/cmd/kmod_installer/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=gcr.io/cos-cloud/cos-dkms:v0.3.12 /usr/bin/cos-dkms /usr/bin/cos-dkms
+COPY --from=gcr.io/cos-cloud/cos-dkms:v0.3.16 /usr/bin/cos-dkms /usr/bin/cos-dkms
 
 COPY /cmd/kmod_installer/entrypoint.sh /usr/bin/entrypoint.sh
 RUN chmod +x /usr/bin/entrypoint.sh


### PR DESCRIPTION
Updates cos-dkms image version in cmd/kmod_installer/Dockerfile from v0.3.12 to v0.3.16 to resolve 10 Go standard library CVEs