### PR TITLE
Support configurable GKE release channel for integration tests

### DIFF
--- a/test/k8s-integration/cluster.go
+++ b/test/k8s-integration/cluster.go
@@ -167,7 +167,10 @@ func clusterUpGKE(project, gceZone, gceRegion, imageType string, numNodes, multi
 
 	if isVariableSet(gkeClusterVersion) {
 		cmdParams = append(cmdParams, "--cluster-version", *gkeClusterVersion)
-		cmdParams = append(cmdParams, "--release-channel", "rapid")
+	}
+
+	if isVariableSet(gkeReleaseChannel) {
+		cmdParams = append(cmdParams, "--release-channel", *gkeReleaseChannel)
 	}
 
 	if isVariableSet(gkeNodeVersion) {

--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -63,6 +63,7 @@ var (
 	gkeClusterVersion      = flag.String("gke-cluster-version", "", "version of k8s master and node for GKE cluster")
 	gkeNodeVersion         = flag.String("gke-node-version", "", "GKE cluster worker node version")
 	gkeTestClusterName     = flag.String("gke-cluster-name", "", "GKE cluster name")
+	gkeReleaseChannel      = flag.String("gke-release-channel", "rapid", "GKE release channel")
 	gceZone                = flag.String("gce-zone", "", "zone that the gke zonal cluster is created/found in")
 	gceRegion              = flag.String("gce-region", "", "region that the gke regional cluster should be created in")
 	clusterNetwork         = flag.String("cluster-network", "lustre-network", "the VPC network to be used by the GKE cluster")

--- a/test/run-k8s-integration-local.sh
+++ b/test/run-k8s-integration-local.sh
@@ -19,6 +19,8 @@ readonly PKGDIR="$( realpath -s "$(dirname "$SCRIPTDIR")" )"
 echo "PKGDIR is $PKGDIR"
 readonly lustre_endpoint="${LUSTRE_ENDPOINT:-prod}"
 echo "lustre_endpoint is $lustre_endpoint"
+readonly gke_release_channel="${GKE_RELEASE_CHANNEL:-rapid}"
+echo "gke_release_channel is $gke_release_channel"
 
 # Some commonly run subset of tests focus strings.
 all_external_tests_focus="External.*Storage"
@@ -30,5 +32,6 @@ multivolume_fs_test_focus="External.*Storage.*filesystem.*multiVolume"
 --bringup-cluster=true --test-focus="${all_external_tests_focus}" --do-network-setup=true \
 --do-driver-build=true --gce-zone="us-central1-a" --use-gke-driver=false \
 --num-nodes="${NUM_NODES:-1}" --multi-nic-num-nodes="${MULTI_NIC_NUM_NODES:-1}" --parallel=1 \
---test-version=1.36 --gke-cluster-version=1.36 --image-type="${IMAGE_TYPE:-cos_containerd}" \
+--test-version=1.36 --gke-cluster-version=1.36 --gke-release-channel="${gke_release_channel}" \
+--image-type="${IMAGE_TYPE:-cos_containerd}" \
 --lustre-endpoint="${lustre_endpoint}"

--- a/test/run-k8s-integration.sh
+++ b/test/run-k8s-integration.sh
@@ -35,6 +35,7 @@ readonly parallel_run=${PARALLEL:-}
 readonly test_focus=${TEST_FOCUS:-}
 readonly test_version=${TEST_VERSION:-1.32}
 readonly enable_legacy_lustre_port=${ENABLE_LEGACY_LUSTRE_PORT:-true}
+readonly gke_release_channel=${GKE_RELEASE_CHANNEL:-rapid}
 readonly image_type="${IMAGE_TYPE:-cos_containerd}"
 
 make -C "${PKGDIR}" test-k8s-integration
@@ -52,6 +53,7 @@ base_cmd="${PKGDIR}/bin/k8s-integration-test \
             --do-driver-build=${do_driver_build} --boskos-resource-type=${boskos_resource_type} \
             --test-version=${test_version} --num-nodes=1 --multi-nic-num-nodes=1 --pkg-dir=${PKGDIR} \
             --use-gke-driver=${use_gke_driver} --gke-cluster-version=${gke_cluster_version} \
+            --gke-release-channel=${gke_release_channel} \
             --enable-legacy-lustre-port=${enable_legacy_lustre_port} --image-type=${image_type} \
             --lustre-endpoint=${lustre_endpoint}"
 


### PR DESCRIPTION
### Description
Add `--gke-release-channel` flag to the integration test harness and pass `GKE_RELEASE_CHANNEL` from `run-k8s-integration.sh` and `run-k8s-integration-local.sh`.

### Why
This allows test jobs for GKE versions (such as 1.33) that have transitioned to the `extended` channel to specify `GKE_RELEASE_CHANNEL=extended`, preventing cluster creation failures (`ResponseError 400: No valid versions with the prefix found`) caused by requesting an older version on the `rapid` channel.

Defaults to `rapid` to preserve existing behavior for current active versions.